### PR TITLE
feat(auth): implement register page flow

### DIFF
--- a/src/features/auth/register.js
+++ b/src/features/auth/register.js
@@ -1,0 +1,115 @@
+import { registerUser, validateRegistrationForm } from "../../services/auth.js";
+
+export function renderRegisterPage(rootElement) {
+	if (!rootElement) {
+		return;
+	}
+
+	rootElement.innerHTML = `
+		<main class="page">
+			<section class="login-card" aria-labelledby="register-title">
+				<h1 id="register-title" class="title">Register</h1>
+				<form class="login-form" id="register-form" novalidate>
+					<label class="field-label" for="name">Name</label>
+					<input
+						class="field-input"
+						id="name"
+						name="name"
+						type="text"
+						autocomplete="username"
+						placeholder="username"
+						required
+					/>
+					<p class="field-error" data-error-for="name" aria-live="polite"></p>
+
+					<label class="field-label" for="email">Email</label>
+					<input
+						class="field-input"
+						id="email"
+						name="email"
+						type="email"
+						autocomplete="email"
+						placeholder="name@stud.noroff.no"
+						required
+					/>
+					<p class="field-error" data-error-for="email" aria-live="polite"></p>
+
+					<label class="field-label" for="password">Password</label>
+					<input
+						class="field-input"
+						id="password"
+						name="password"
+						type="password"
+						autocomplete="new-password"
+						placeholder="Minimum 8 characters"
+						required
+					/>
+					<p class="field-error" data-error-for="password" aria-live="polite"></p>
+
+					<button class="submit-button" id="register-submit" type="submit">Create account</button>
+					<p class="form-message" id="register-message" aria-live="polite"></p>
+				</form>
+				<p class="register-text">
+					Already have an account?
+					<a class="register-link" href="#login">Log in</a>
+				</p>
+			</section>
+		</main>
+	`;
+
+	const registerForm = rootElement.querySelector("#register-form");
+	const submitButton = rootElement.querySelector("#register-submit");
+	const messageElement = rootElement.querySelector("#register-message");
+	const nameError = rootElement.querySelector('[data-error-for="name"]');
+	const emailError = rootElement.querySelector('[data-error-for="email"]');
+	const passwordError = rootElement.querySelector('[data-error-for="password"]');
+
+	if (!registerForm || !submitButton || !messageElement || !nameError || !emailError || !passwordError) {
+		return;
+	}
+
+	registerForm.addEventListener("submit", async (event) => {
+		event.preventDefault();
+
+		messageElement.textContent = "";
+		messageElement.classList.remove("is-error", "is-success");
+		nameError.textContent = "";
+		emailError.textContent = "";
+		passwordError.textContent = "";
+
+		const formData = new FormData(registerForm);
+		const registrationData = {
+			name: String(formData.get("name") || ""),
+			email: String(formData.get("email") || ""),
+			password: String(formData.get("password") || ""),
+		};
+
+		const validation = validateRegistrationForm(registrationData);
+
+		if (!validation.isValid) {
+			nameError.textContent = validation.errors.name || "";
+			emailError.textContent = validation.errors.email || "";
+			passwordError.textContent = validation.errors.password || "";
+			return;
+		}
+
+		submitButton.disabled = true;
+		submitButton.textContent = "Creating...";
+
+		try {
+			await registerUser(validation.data);
+			messageElement.textContent = "Registration successful. Redirecting to login...";
+			messageElement.classList.add("is-success");
+
+			setTimeout(() => {
+				window.location.hash = "#login";
+			}, 700);
+		} catch (error) {
+			messageElement.textContent = error.message || "Registration failed. Please try again.";
+			messageElement.classList.add("is-error");
+		} finally {
+			submitButton.disabled = false;
+			submitButton.textContent = "Create account";
+		}
+	});
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,21 @@
 import "./styles/main.css";
 import { renderLoginPage } from "./features/auth/login.js";
+import { renderRegisterPage } from "./features/auth/register.js";
 
 const app = document.querySelector("#app");
-renderLoginPage(app);
+
+function renderCurrentPage() {
+	if (!app) {
+		return;
+	}
+
+	if (window.location.hash === "#register") {
+		renderRegisterPage(app);
+		return;
+	}
+
+	renderLoginPage(app);
+}
+
+window.addEventListener("hashchange", renderCurrentPage);
+renderCurrentPage();

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -43,3 +43,63 @@ export async function loginUser(credentials) {
 
 	return responseBody?.data;
 }
+
+export function validateRegistrationForm(formData) {
+	const errors = {};
+	const name = (formData.name || "").trim();
+	const email = (formData.email || "").trim();
+	const password = String(formData.password || "");
+
+	if (name === "") {
+		errors.name = "Name is required";
+	}
+
+	if (name && !/^[A-Za-z0-9_]+$/.test(name)) {
+		errors.name = "Name can only use letters, numbers, and underscore";
+	}
+
+	if (email === "") {
+		errors.email = "Email is required";
+	}
+
+	if (email && !/^[^\s@]+@stud\.noroff\.no$/i.test(email)) {
+		errors.email = "Use a @stud.noroff.no email";
+	}
+
+	if (password.trim() === "") {
+		errors.password = "Password is required";
+	}
+
+	if (password && password.length < 8) {
+		errors.password = "Password must be at least 8 characters";
+	}
+
+	return {
+		isValid: Object.keys(errors).length === 0,
+		errors,
+		data: {
+			name,
+			email,
+			password,
+		},
+	};
+}
+
+export async function registerUser(userData) {
+	const response = await fetch(`${API_BASE_URL}/auth/register`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(userData),
+	});
+
+	const responseBody = await response.json().catch(() => ({}));
+
+	if (!response.ok) {
+		const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+		throw new Error(apiMessage || "Registration failed");
+	}
+
+	return responseBody?.data;
+}


### PR DESCRIPTION
## What this PR does
This PR adds the register page feature for issue #1 

## Changes made
- Added a register page UI with fields:
  - name
  - email
  - password
- Added client-side validation for:
  - name format (letters, numbers, underscore)
  - stud email format (`@stud.noroff.no`)
  - password minimum length (8)
- Added register API call to Noroff auth register endpoint
- Added clear inline error messages and form feedback messages
- Added redirect back to login after successful registration
- Added simple hash-based page switching between login and register in main app entry

## Files changed
- src/main.js
- src/features/auth/register.js
- src/services/auth.js

## How to test
1. Run `npm run dev`
2. Open app and go to `#register`
3. Try invalid and valid inputs
4. Confirm errors show correctly
5. Confirm successful registration redirects to login

## Build
- `npm run build` passes

Closes #1