### PR TITLE
feat(feed): build feed page with load-more pagination

### DIFF
--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -1,0 +1,166 @@
+import { fetchFeedPosts } from "../../services/api.js";
+import { clearAuthData, getAccessToken, getCurrentUser } from "../../services/storage.js";
+
+function formatDate(dateString) {
+	if (!dateString) {
+		return "Unknown date";
+	}
+
+	const date = new Date(dateString);
+	return date.toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+function truncateText(text, maxLength = 150) {
+	const value = text || "";
+
+	if (value.length <= maxLength) {
+		return value;
+	}
+
+	return `${value.slice(0, maxLength)}...`;
+}
+
+function getMediaUrl(media) {
+	if (!media) {
+		return "";
+	}
+
+	if (typeof media === "string") {
+		return media;
+	}
+
+	if (typeof media === "object" && media.url) {
+		return media.url;
+	}
+
+	return "";
+}
+
+function renderPostCard(post) {
+	const mediaUrl = getMediaUrl(post.media);
+
+	return `
+		<article class="post-card">
+			<div class="post-header">
+				<p class="post-author">${post.author?.name || "Unknown"}</p>
+				<p class="post-date">${formatDate(post.created)}</p>
+			</div>
+			<h2 class="post-title">${post.title || "Untitled post"}</h2>
+			<p class="post-body">${truncateText(post.body)}</p>
+			${mediaUrl ? `<img class="post-media" src="${mediaUrl}" alt="Post media" loading="lazy" />` : ""}
+			<div class="post-meta">
+				<span>${post._count?.comments || 0} comments</span>
+				<span>${post._count?.reactions || 0} reactions</span>
+			</div>
+		</article>
+	`;
+}
+
+export function renderFeedPage(rootElement) {
+	if (!rootElement) {
+		return;
+	}
+
+	const accessToken = getAccessToken();
+
+	if (!accessToken) {
+		window.location.hash = "#login";
+		return;
+	}
+
+	const currentUser = getCurrentUser();
+
+	rootElement.innerHTML = `
+		<main class="feed-page">
+			<header class="feed-topbar">
+				<div>
+					<h1 class="feed-title">Feed</h1>
+					<p class="feed-subtitle">Logged in as ${currentUser.name || "User"}</p>
+				</div>
+				<button class="logout-button" id="logout-button" type="button">Log Out</button>
+			</header>
+
+			<p class="feed-message" id="feed-message" aria-live="polite"></p>
+			<section class="feed-grid" id="feed-grid"></section>
+			<button class="load-more-button" id="load-more-button" type="button">Load More</button>
+		</main>
+	`;
+
+	const feedGrid = rootElement.querySelector("#feed-grid");
+	const feedMessage = rootElement.querySelector("#feed-message");
+	const loadMoreButton = rootElement.querySelector("#load-more-button");
+	const logoutButton = rootElement.querySelector("#logout-button");
+
+	if (!feedGrid || !feedMessage || !loadMoreButton || !logoutButton) {
+		return;
+	}
+
+	let currentPage = 1;
+	let isLastPage = false;
+	let isLoading = false;
+
+	logoutButton.addEventListener("click", () => {
+		clearAuthData();
+		window.location.hash = "#login";
+	});
+
+	async function loadPosts() {
+		if (isLoading || isLastPage) {
+			return;
+		}
+
+		isLoading = true;
+		feedMessage.textContent = "Loading posts...";
+		loadMoreButton.disabled = true;
+
+		try {
+			const result = await fetchFeedPosts({
+				accessToken,
+				page: currentPage,
+				limit: 12,
+			});
+
+			if (result.posts.length === 0 && currentPage === 1) {
+				feedGrid.innerHTML = "";
+				feedMessage.textContent = "No posts found yet.";
+				loadMoreButton.style.display = "none";
+				isLastPage = true;
+				return;
+			}
+
+			feedGrid.insertAdjacentHTML(
+				"beforeend",
+				result.posts.map((post) => renderPostCard(post)).join(""),
+			);
+
+			feedMessage.textContent = "";
+			isLastPage = Boolean(result.meta?.isLastPage);
+
+			if (isLastPage) {
+				loadMoreButton.style.display = "none";
+			} else {
+				currentPage += 1;
+				loadMoreButton.disabled = false;
+			}
+		} catch (error) {
+			feedMessage.textContent = error.message || "Could not load feed.";
+
+			if ((error.message || "").toLowerCase().includes("unauthorized")) {
+				clearAuthData();
+				window.location.hash = "#login";
+				return;
+			}
+
+			loadMoreButton.disabled = false;
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	loadMoreButton.addEventListener("click", loadPosts);
+	loadPosts();
+}

--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -24,37 +24,56 @@ function truncateText(text, maxLength = 150) {
 	return `${value.slice(0, maxLength)}...`;
 }
 
+function escapeHtml(value) {
+	return String(value || "")
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
 function getMediaUrl(media) {
-	if (!media) {
+	const rawUrl = typeof media === "string" ? media : media?.url;
+
+	if (!rawUrl) {
 		return "";
 	}
 
-	if (typeof media === "string") {
-		return media;
-	}
+	try {
+		const parsed = new URL(rawUrl);
 
-	if (typeof media === "object" && media.url) {
-		return media.url;
-	}
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			return "";
+		}
 
-	return "";
+		return parsed.toString();
+	} catch {
+		return "";
+	}
 }
 
 function renderPostCard(post) {
 	const mediaUrl = getMediaUrl(post.media);
+	const authorName = escapeHtml(post.author?.name || "Unknown");
+	const postDate = escapeHtml(formatDate(post.created));
+	const postTitle = escapeHtml(post.title || "Untitled post");
+	const postBody = escapeHtml(truncateText(post.body));
+	const commentsCount = Number(post._count?.comments || 0);
+	const reactionsCount = Number(post._count?.reactions || 0);
 
 	return `
 		<article class="post-card">
 			<div class="post-header">
-				<p class="post-author">${post.author?.name || "Unknown"}</p>
-				<p class="post-date">${formatDate(post.created)}</p>
+				<p class="post-author">${authorName}</p>
+				<p class="post-date">${postDate}</p>
 			</div>
-			<h2 class="post-title">${post.title || "Untitled post"}</h2>
-			<p class="post-body">${truncateText(post.body)}</p>
-			${mediaUrl ? `<img class="post-media" src="${mediaUrl}" alt="Post media" loading="lazy" />` : ""}
+			<h2 class="post-title">${postTitle}</h2>
+			<p class="post-body">${postBody}</p>
+			${mediaUrl ? `<img class="post-media" src="${mediaUrl}" alt="Post media" loading="lazy" width="640" height="360" />` : ""}
 			<div class="post-meta">
-				<span>${post._count?.comments || 0} comments</span>
-				<span>${post._count?.reactions || 0} reactions</span>
+				<span>${commentsCount} comments</span>
+				<span>${reactionsCount} reactions</span>
 			</div>
 		</article>
 	`;
@@ -73,13 +92,14 @@ export function renderFeedPage(rootElement) {
 	}
 
 	const currentUser = getCurrentUser();
+	const safeUserName = escapeHtml(currentUser.name || "User");
 
 	rootElement.innerHTML = `
 		<main class="feed-page">
 			<header class="feed-topbar">
 				<div>
 					<h1 class="feed-title">Feed</h1>
-					<p class="feed-subtitle">Logged in as ${currentUser.name || "User"}</p>
+					<p class="feed-subtitle">Logged in as ${safeUserName}</p>
 				</div>
 				<button class="logout-button" id="logout-button" type="button">Log Out</button>
 			</header>
@@ -149,7 +169,7 @@ export function renderFeedPage(rootElement) {
 		} catch (error) {
 			feedMessage.textContent = error.message || "Could not load feed.";
 
-			if ((error.message || "").toLowerCase().includes("unauthorized")) {
+			if (error.status === 401) {
 				clearAuthData();
 				window.location.hash = "#login";
 				return;

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,8 @@
 import "./styles/main.css";
+import { renderFeedPage } from "./features/feed/feed.js";
 import { renderLoginPage } from "./features/auth/login.js";
 import { renderRegisterPage } from "./features/auth/register.js";
+import { getAccessToken } from "./services/storage.js";
 
 const app = document.querySelector("#app");
 
@@ -11,6 +13,16 @@ function renderCurrentPage() {
 
 	if (window.location.hash === "#register") {
 		renderRegisterPage(app);
+		return;
+	}
+
+	if (window.location.hash === "#feed") {
+		if (!getAccessToken()) {
+			window.location.hash = "#login";
+			return;
+		}
+
+		renderFeedPage(app);
 		return;
 	}
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,6 +1,15 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+const API_KEY = import.meta.env.VITE_NOROFF_API_KEY;
 
 export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
+	if (!API_BASE_URL) {
+		throw new Error("Missing VITE_API_BASE_URL in .env");
+	}
+
+	if (!API_KEY) {
+		throw new Error("Missing VITE_NOROFF_API_KEY in .env");
+	}
+
 	const query = new URLSearchParams({
 		page: String(page),
 		limit: String(limit),
@@ -12,7 +21,7 @@ export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
 	const response = await fetch(`${API_BASE_URL}/social/posts?${query.toString()}`, {
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
-			"X-Noroff-API-Key": import.meta.env.VITE_NOROFF_API_KEY,
+			"X-Noroff-API-Key": API_KEY,
 		},
 	});
 
@@ -20,7 +29,9 @@ export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
 
 	if (!response.ok) {
 		const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-		throw new Error(apiMessage || "Failed to load feed");
+		const error = new Error(apiMessage || "Failed to load feed");
+		error.status = response.status;
+		throw error;
 	}
 
 	return {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,30 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
+	const query = new URLSearchParams({
+		page: String(page),
+		limit: String(limit),
+		_author: "true",
+		_comments: "true",
+		_reactions: "true",
+	});
+
+	const response = await fetch(`${API_BASE_URL}/social/posts?${query.toString()}`, {
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"X-Noroff-API-Key": import.meta.env.VITE_NOROFF_API_KEY,
+		},
+	});
+
+	const responseBody = await response.json().catch(() => ({}));
+
+	if (!response.ok) {
+		const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+		throw new Error(apiMessage || "Failed to load feed");
+	}
+
+	return {
+		posts: responseBody?.data || [],
+		meta: responseBody?.meta || {},
+	};
+}

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -9,3 +9,14 @@ export function clearAuthData() {
 	localStorage.removeItem("userName");
 	localStorage.removeItem("userEmail");
 }
+
+export function getAccessToken() {
+	return localStorage.getItem("accessToken") || "";
+}
+
+export function getCurrentUser() {
+	return {
+		name: localStorage.getItem("userName") || "",
+		email: localStorage.getItem("userEmail") || "",
+	};
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -49,7 +49,11 @@ body {
 	color: #000000;
 	padding: 0.7rem 0.8rem;
 	font-size: 1rem;
-	outline: none;
+}
+
+.field-input:focus-visible {
+	outline: 2px solid #ffffff;
+	outline-offset: 2px;
 }
 
 .field-error {
@@ -103,6 +107,121 @@ body {
 .register-link {
 	color: #ffffff;
 	font-weight: 700;
+}
+
+.feed-page {
+	min-height: 100vh;
+	max-width: 1000px;
+	margin: 0 auto;
+	padding: 1rem;
+}
+
+.feed-topbar {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 1rem;
+	margin-bottom: 1rem;
+}
+
+.feed-title {
+	margin: 0;
+	font-size: 1.6rem;
+	color: #111111;
+}
+
+.feed-subtitle {
+	margin: 0.2rem 0 0;
+	color: #444444;
+	font-size: 0.95rem;
+}
+
+.logout-button {
+	border: 1px solid #111111;
+	background: #ffffff;
+	color: #111111;
+	padding: 0.5rem 0.8rem;
+	font-weight: 700;
+	border-radius: 4px;
+	cursor: pointer;
+}
+
+.feed-message {
+	margin: 0.3rem 0 1rem;
+	color: #444444;
+	min-height: 1.2rem;
+}
+
+.feed-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+	gap: 1rem;
+}
+
+.post-card {
+	border: 1px solid #dddddd;
+	border-radius: 8px;
+	padding: 1rem;
+	background: #ffffff;
+}
+
+.post-header {
+	display: flex;
+	justify-content: space-between;
+	gap: 0.5rem;
+	margin-bottom: 0.5rem;
+	font-size: 0.85rem;
+	color: #666666;
+}
+
+.post-author {
+	margin: 0;
+	font-weight: 700;
+	color: #111111;
+}
+
+.post-date {
+	margin: 0;
+}
+
+.post-title {
+	margin: 0 0 0.4rem;
+	font-size: 1.1rem;
+	color: #111111;
+}
+
+.post-body {
+	margin: 0 0 0.75rem;
+	color: #333333;
+	line-height: 1.4;
+}
+
+.post-media {
+	display: block;
+	width: 100%;
+	height: auto;
+	border-radius: 6px;
+	margin-bottom: 0.7rem;
+	object-fit: cover;
+}
+
+.post-meta {
+	display: flex;
+	gap: 0.8rem;
+	font-size: 0.85rem;
+	color: #555555;
+}
+
+.load-more-button {
+	display: block;
+	margin: 1rem auto 0;
+	border: 1px solid #111111;
+	background: #111111;
+	color: #ffffff;
+	padding: 0.6rem 0.9rem;
+	font-weight: 700;
+	border-radius: 4px;
+	cursor: pointer;
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
## What this PR does
This PR implements issue #3: get and show all posts on the feed page.

## Changes made
- Added feed page rendering with a post card layout
- Added API request for paginated posts with:
  - author data
  - comments count
  - reactions count
- Added loading state, empty state, and error message handling
- Added Load More pagination button
- Added basic auth guard for feed route
- Added logout button on feed page
- Added simple hash route support for:
  - #login
  - #register
  - #feed

## Post card shows
- title
- author
- date
- body excerpt
- media (if available)
- comments count
- reactions count

## Files changed
- src/features/feed/feed.js
- src/main.js
- src/services/api.js
- src/services/storage.js
- src/styles/main.css

## Build check
- npm run build passes

Closes #3