### PR TITLE
feat: get single post on click

### DIFF
--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -55,6 +55,7 @@ function getMediaUrl(media) {
 
 function renderPostCard(post) {
 	const mediaUrl = getMediaUrl(post.media);
+	const postId = escapeHtml(post.id);
 	const authorName = escapeHtml(post.author?.name || "Unknown");
 	const postDate = escapeHtml(formatDate(post.created));
 	const postTitle = escapeHtml(post.title || "Untitled post");
@@ -63,7 +64,7 @@ function renderPostCard(post) {
 	const reactionsCount = Number(post._count?.reactions || 0);
 
 	return `
-		<article class="post-card">
+		<article class="post-card" data-post-id="${postId}">
 			<div class="post-header">
 				<p class="post-author">${authorName}</p>
 				<p class="post-date">${postDate}</p>
@@ -75,6 +76,7 @@ function renderPostCard(post) {
 				<span>${commentsCount} comments</span>
 				<span>${reactionsCount} reactions</span>
 			</div>
+			<button class="post-open-button" type="button" data-post-id="${postId}">Open post</button>
 		</article>
 	`;
 }
@@ -118,6 +120,28 @@ export function renderFeedPage(rootElement) {
 	if (!feedGrid || !feedMessage || !loadMoreButton || !logoutButton) {
 		return;
 	}
+
+	feedGrid.addEventListener("click", (event) => {
+		const target = event.target;
+
+		if (!(target instanceof Element)) {
+			return;
+		}
+
+		const trigger = target.closest("[data-post-id]");
+
+		if (!trigger) {
+			return;
+		}
+
+		const postId = trigger.getAttribute("data-post-id");
+
+		if (!postId) {
+			return;
+		}
+
+		window.location.hash = `#post?id=${encodeURIComponent(postId)}`;
+	});
 
 	let currentPage = 1;
 	let isLastPage = false;

--- a/src/features/feed/post-detail.js
+++ b/src/features/feed/post-detail.js
@@ -1,0 +1,204 @@
+import { fetchPostById } from "../../services/api.js";
+import { clearAuthData, getAccessToken } from "../../services/storage.js";
+
+function escapeHtml(value) {
+	return String(value || "")
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+function formatDateTime(dateString) {
+	if (!dateString) {
+		return "Unknown date";
+	}
+
+	const date = new Date(dateString);
+
+	return date.toLocaleString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}
+
+function getMediaUrl(media) {
+	const rawUrl = typeof media === "string" ? media : media?.url;
+
+	if (!rawUrl) {
+		return "";
+	}
+
+	try {
+		const parsed = new URL(rawUrl);
+
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			return "";
+		}
+
+		return parsed.toString();
+	} catch {
+		return "";
+	}
+}
+
+function renderComments(comments = []) {
+	if (!Array.isArray(comments) || comments.length === 0) {
+		return '<p class="detail-empty">No comments yet.</p>';
+	}
+
+	return `
+		<ul class="detail-comments-list">
+			${comments
+				.map((comment) => {
+					const owner = escapeHtml(comment.owner || "Unknown");
+					const body = escapeHtml(comment.body || "");
+					const created = escapeHtml(formatDateTime(comment.created));
+
+					return `
+						<li class="detail-comment-item">
+							<p class="detail-comment-head">${owner} • ${created}</p>
+							<p class="detail-comment-body">${body}</p>
+						</li>
+					`;
+				})
+				.join("")}
+		</ul>
+	`;
+}
+
+function renderReactions(reactions = []) {
+	if (!Array.isArray(reactions) || reactions.length === 0) {
+		return '<p class="detail-empty">No reactions yet.</p>';
+	}
+
+	return `
+		<ul class="detail-reaction-list">
+			${reactions
+				.map((reaction) => {
+					const symbol = escapeHtml(reaction.symbol || "?");
+					const count = Number(reaction.count || 0);
+					return `<li class="detail-reaction-item">${symbol} ${count}</li>`;
+				})
+				.join("")}
+		</ul>
+	`;
+}
+
+function renderPostDetail(post) {
+	const title = escapeHtml(post?.title || "Untitled post");
+	const body = escapeHtml(post?.body || "");
+	const authorName = escapeHtml(post?.author?.name || "Unknown");
+	const authorEmail = escapeHtml(post?.author?.email || "No email");
+	const created = escapeHtml(formatDateTime(post?.created));
+	const mediaUrl = getMediaUrl(post?.media);
+	const tags = Array.isArray(post?.tags) ? post.tags : [];
+	const safeTags = tags.map((tag) => escapeHtml(tag)).filter(Boolean);
+	const commentsCount = Number(post?._count?.comments || post?.comments?.length || 0);
+	const reactionsCount = Number(post?._count?.reactions || 0);
+
+	return `
+		<article class="post-detail-card">
+			<header class="post-detail-header">
+				<p class="post-detail-author">${authorName}</p>
+				<p class="post-detail-email">${authorEmail}</p>
+				<p class="post-detail-date">${created}</p>
+			</header>
+
+			<h1 class="post-detail-title">${title}</h1>
+			<p class="post-detail-body">${body}</p>
+
+			${mediaUrl ? `<img class="post-detail-media" src="${mediaUrl}" alt="Post media" loading="lazy" />` : ""}
+
+			${
+				safeTags.length > 0
+					? `<ul class="post-detail-tags">${safeTags.map((tag) => `<li>#${tag}</li>`).join("")}</ul>`
+					: ""
+			}
+
+			<div class="post-detail-counts">
+				<span>${commentsCount} comments</span>
+				<span>${reactionsCount} reactions</span>
+			</div>
+
+			<section class="post-detail-section">
+				<h2>Reactions</h2>
+				${renderReactions(post?.reactions)}
+			</section>
+
+			<section class="post-detail-section">
+				<h2>Comments</h2>
+				${renderComments(post?.comments)}
+			</section>
+		</article>
+	`;
+}
+
+export function renderPostDetailPage(rootElement, postId) {
+	if (!rootElement) {
+		return;
+	}
+
+	const accessToken = getAccessToken();
+
+	if (!accessToken) {
+		window.location.hash = "#login";
+		return;
+	}
+
+	rootElement.innerHTML = `
+		<main class="feed-page">
+			<header class="detail-topbar">
+				<button class="back-button" id="back-to-feed" type="button">Back to feed</button>
+			</header>
+			<p class="feed-message" id="post-detail-message" aria-live="polite">Loading post...</p>
+			<section id="post-detail-content"></section>
+		</main>
+	`;
+
+	const backButton = rootElement.querySelector("#back-to-feed");
+	const messageElement = rootElement.querySelector("#post-detail-message");
+	const contentElement = rootElement.querySelector("#post-detail-content");
+
+	if (!backButton || !messageElement || !contentElement) {
+		return;
+	}
+
+	backButton.addEventListener("click", () => {
+		window.location.hash = "#feed";
+	});
+
+	if (!postId) {
+		messageElement.textContent = "Missing post id in URL.";
+		return;
+	}
+
+	fetchPostById({ accessToken, postId })
+		.then((post) => {
+			if (!post) {
+				messageElement.textContent = "Post not found.";
+				return;
+			}
+
+			messageElement.textContent = "";
+			contentElement.innerHTML = renderPostDetail(post);
+		})
+		.catch((error) => {
+			if (error.status === 401) {
+				clearAuthData();
+				window.location.hash = "#login";
+				return;
+			}
+
+			if (error.status === 404) {
+				messageElement.textContent = "Post not found.";
+				return;
+			}
+
+			messageElement.textContent = error.message || "Could not load post.";
+		});
+}

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,22 @@ import "./styles/main.css";
 import { renderFeedPage } from "./features/feed/feed.js";
 import { renderLoginPage } from "./features/auth/login.js";
 import { renderRegisterPage } from "./features/auth/register.js";
+import { renderPostDetailPage } from "./features/feed/post-detail.js";
 import { getAccessToken } from "./services/storage.js";
 
 const app = document.querySelector("#app");
+
+function getPostIdFromHash() {
+	const hashValue = window.location.hash || "";
+
+	if (!hashValue.startsWith("#post")) {
+		return "";
+	}
+
+	const queryString = hashValue.split("?")[1] || "";
+	const params = new URLSearchParams(queryString);
+	return params.get("id") || "";
+}
 
 function renderCurrentPage() {
 	if (!app) {
@@ -23,6 +36,16 @@ function renderCurrentPage() {
 		}
 
 		renderFeedPage(app);
+		return;
+	}
+
+	if (window.location.hash.startsWith("#post")) {
+		if (!getAccessToken()) {
+			window.location.hash = "#login";
+			return;
+		}
+
+		renderPostDetailPage(app, getPostIdFromHash());
 		return;
 	}
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 const API_KEY = import.meta.env.VITE_NOROFF_API_KEY;
 
-export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
+function assertApiConfig() {
 	if (!API_BASE_URL) {
 		throw new Error("Missing VITE_API_BASE_URL in .env");
 	}
@@ -9,6 +9,10 @@ export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
 	if (!API_KEY) {
 		throw new Error("Missing VITE_NOROFF_API_KEY in .env");
 	}
+}
+
+export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
+	assertApiConfig();
 
 	const query = new URLSearchParams({
 		page: String(page),
@@ -38,4 +42,36 @@ export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
 		posts: responseBody?.data || [],
 		meta: responseBody?.meta || {},
 	};
+}
+
+export async function fetchPostById({ accessToken, postId }) {
+	assertApiConfig();
+
+	if (!postId) {
+		throw new Error("Post id is required");
+	}
+
+	const query = new URLSearchParams({
+		_author: "true",
+		_comments: "true",
+		_reactions: "true",
+	});
+
+	const response = await fetch(`${API_BASE_URL}/social/posts/${encodeURIComponent(postId)}?${query.toString()}`, {
+		headers: {
+			Authorization: `Bearer ${accessToken}`,
+			"X-Noroff-API-Key": API_KEY,
+		},
+	});
+
+	const responseBody = await response.json().catch(() => ({}));
+
+	if (!response.ok) {
+		const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+		const error = new Error(apiMessage || "Failed to load post");
+		error.status = response.status;
+		throw error;
+	}
+
+	return responseBody?.data || null;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -212,6 +212,17 @@ body {
 	color: #555555;
 }
 
+.post-open-button {
+	margin-top: 0.9rem;
+	border: 1px solid #111111;
+	background: #ffffff;
+	color: #111111;
+	padding: 0.45rem 0.7rem;
+	border-radius: 4px;
+	font-weight: 700;
+	cursor: pointer;
+}
+
 .load-more-button {
 	display: block;
 	margin: 1rem auto 0;
@@ -222,6 +233,132 @@ body {
 	font-weight: 700;
 	border-radius: 4px;
 	cursor: pointer;
+}
+
+.detail-topbar {
+	margin-bottom: 1rem;
+}
+
+.back-button {
+	border: 1px solid #111111;
+	background: #ffffff;
+	color: #111111;
+	padding: 0.5rem 0.8rem;
+	font-weight: 700;
+	border-radius: 4px;
+	cursor: pointer;
+}
+
+.post-detail-card {
+	border: 1px solid #dddddd;
+	border-radius: 8px;
+	padding: 1rem;
+	background: #ffffff;
+}
+
+.post-detail-header {
+	display: grid;
+	gap: 0.2rem;
+	margin-bottom: 0.7rem;
+}
+
+.post-detail-author,
+.post-detail-email,
+.post-detail-date {
+	margin: 0;
+	color: #444444;
+	font-size: 0.92rem;
+}
+
+.post-detail-title {
+	margin: 0 0 0.6rem;
+	color: #111111;
+}
+
+.post-detail-body {
+	margin: 0;
+	color: #333333;
+	line-height: 1.5;
+	white-space: pre-wrap;
+}
+
+.post-detail-media {
+	display: block;
+	width: 100%;
+	height: auto;
+	margin: 0.9rem 0 0;
+	border-radius: 6px;
+}
+
+.post-detail-tags {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	list-style: none;
+	padding: 0;
+	margin: 0.9rem 0 0;
+}
+
+.post-detail-tags li {
+	border: 1px solid #cccccc;
+	border-radius: 999px;
+	padding: 0.2rem 0.55rem;
+	font-size: 0.85rem;
+	color: #333333;
+}
+
+.post-detail-counts {
+	display: flex;
+	gap: 0.8rem;
+	font-size: 0.9rem;
+	color: #555555;
+	margin: 0.9rem 0 0;
+}
+
+.post-detail-section {
+	margin-top: 1rem;
+	padding-top: 0.8rem;
+	border-top: 1px solid #efefef;
+}
+
+.post-detail-section h2 {
+	margin: 0 0 0.6rem;
+	font-size: 1rem;
+	color: #111111;
+}
+
+.detail-reaction-list,
+.detail-comments-list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: grid;
+	gap: 0.55rem;
+}
+
+.detail-reaction-item,
+.detail-comment-item {
+	border: 1px solid #eeeeee;
+	border-radius: 6px;
+	padding: 0.5rem 0.65rem;
+	background: #fafafa;
+}
+
+.detail-comment-head {
+	margin: 0 0 0.3rem;
+	font-size: 0.85rem;
+	color: #666666;
+}
+
+.detail-comment-body {
+	margin: 0;
+	color: #333333;
+	line-height: 1.4;
+}
+
+.detail-empty {
+	margin: 0;
+	color: #666666;
 }
 
 @media (max-width: 520px) {


### PR DESCRIPTION
## Summary
- make feed posts navigable to a single post route using hash query id
- add single-post API fetch with author/comments/reactions
- add post detail page rendering with loading, error, and unauthorized handling
- add back-to-feed navigation and detail styles

## How To Test
- log in and open the feed
- click "Open post" on any card
- confirm URL updates to `#post?id=<postId>`
- verify full post detail (author, content, comments, reactions) is shown
- click "Back to feed" and confirm return to feed

## Build
- `npm run build` passes

Closes #4