### PR TITLE
Consolidate feed/detail helpers, centralize env config, and move hash routing into router.js (#21)

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,0 +1,18 @@
+export function getApiConfig(options = {}) {
+	const { requireApiKey = false } = options;
+	const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
+	const apiKey = import.meta.env.VITE_NOROFF_API_KEY;
+
+	if (!apiBaseUrl) {
+		throw new Error("Missing VITE_API_BASE_URL in .env");
+	}
+
+	if (requireApiKey && !apiKey) {
+		throw new Error("Missing VITE_NOROFF_API_KEY in .env");
+	}
+
+	return {
+		apiBaseUrl,
+		apiKey,
+	};
+}

--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -1,57 +1,6 @@
 import { fetchFeedPosts } from "../../services/api.js";
 import { clearAuthData, getAccessToken, getCurrentUser } from "../../services/storage.js";
-
-function formatDate(dateString) {
-	if (!dateString) {
-		return "Unknown date";
-	}
-
-	const date = new Date(dateString);
-	return date.toLocaleDateString(undefined, {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-	});
-}
-
-function truncateText(text, maxLength = 150) {
-	const value = text || "";
-
-	if (value.length <= maxLength) {
-		return value;
-	}
-
-	return `${value.slice(0, maxLength)}...`;
-}
-
-function escapeHtml(value) {
-	return String(value || "")
-		.replaceAll("&", "&amp;")
-		.replaceAll("<", "&lt;")
-		.replaceAll(">", "&gt;")
-		.replaceAll('"', "&quot;")
-		.replaceAll("'", "&#39;");
-}
-
-function getMediaUrl(media) {
-	const rawUrl = typeof media === "string" ? media : media?.url;
-
-	if (!rawUrl) {
-		return "";
-	}
-
-	try {
-		const parsed = new URL(rawUrl);
-
-		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-			return "";
-		}
-
-		return parsed.toString();
-	} catch {
-		return "";
-	}
-}
+import { escapeHtml, formatDate, getMediaUrl, truncateText } from "../../utils/format.js";
 
 function renderPostCard(post) {
 	const mediaUrl = getMediaUrl(post.media);

--- a/src/features/feed/post-detail.js
+++ b/src/features/feed/post-detail.js
@@ -1,50 +1,6 @@
 import { fetchPostById } from "../../services/api.js";
 import { clearAuthData, getAccessToken } from "../../services/storage.js";
-
-function escapeHtml(value) {
-	return String(value || "")
-		.replaceAll("&", "&amp;")
-		.replaceAll("<", "&lt;")
-		.replaceAll(">", "&gt;")
-		.replaceAll('"', "&quot;")
-		.replaceAll("'", "&#39;");
-}
-
-function formatDateTime(dateString) {
-	if (!dateString) {
-		return "Unknown date";
-	}
-
-	const date = new Date(dateString);
-
-	return date.toLocaleString(undefined, {
-		year: "numeric",
-		month: "short",
-		day: "numeric",
-		hour: "2-digit",
-		minute: "2-digit",
-	});
-}
-
-function getMediaUrl(media) {
-	const rawUrl = typeof media === "string" ? media : media?.url;
-
-	if (!rawUrl) {
-		return "";
-	}
-
-	try {
-		const parsed = new URL(rawUrl);
-
-		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-			return "";
-		}
-
-		return parsed.toString();
-	} catch {
-		return "";
-	}
-}
+import { escapeHtml, formatDateTime, getMediaUrl } from "../../utils/format.js";
 
 function renderComments(comments = []) {
 	if (!Array.isArray(comments) || comments.length === 0) {
@@ -55,7 +11,9 @@ function renderComments(comments = []) {
 		<ul class="detail-comments-list">
 			${comments
 				.map((comment) => {
-					const owner = escapeHtml(comment.owner || "Unknown");
+					const ownerName =
+						typeof comment.owner === "string" ? comment.owner : (comment.owner?.name ?? "Unknown");
+					const owner = escapeHtml(ownerName);
 					const body = escapeHtml(comment.body || "");
 					const created = escapeHtml(formatDateTime(comment.created));
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,51 +3,17 @@ import { renderFeedPage } from "./features/feed/feed.js";
 import { renderLoginPage } from "./features/auth/login.js";
 import { renderRegisterPage } from "./features/auth/register.js";
 import { renderPostDetailPage } from "./features/feed/post-detail.js";
+import { canAccessRoute, createRoutes, getMatchingRoute } from "./router.js";
 import { getAccessToken } from "./services/storage.js";
 
 const app = document.querySelector("#app");
 
-const routes = [
-	{
-		matches: (hash) => hash === "#register",
-		requiresAuth: false,
-		render: (rootElement) => renderRegisterPage(rootElement),
-	},
-	{
-		matches: (hash) => hash === "#feed",
-		requiresAuth: true,
-		render: (rootElement) => renderFeedPage(rootElement),
-	},
-	{
-		matches: (hash) => hash.startsWith("#post"),
-		requiresAuth: true,
-		render: (rootElement) => renderPostDetailPage(rootElement, getPostIdFromHash()),
-	},
-];
-
-function getPostIdFromHash() {
-	const hashValue = window.location.hash || "";
-
-	if (!hashValue.startsWith("#post")) {
-		return "";
-	}
-
-	const queryString = hashValue.split("?")[1] || "";
-	const params = new URLSearchParams(queryString);
-	return params.get("id") || "";
-}
-
-function getMatchingRoute(hash) {
-	return routes.find((route) => route.matches(hash)) || null;
-}
-
-function canAccessRoute(route) {
-	if (!route?.requiresAuth) {
-		return true;
-	}
-
-	return Boolean(getAccessToken());
-}
+const routes = createRoutes({
+	renderLoginPage,
+	renderRegisterPage,
+	renderFeedPage,
+	renderPostDetailPage,
+});
 
 function renderCurrentPage() {
 	if (!app) {
@@ -55,14 +21,9 @@ function renderCurrentPage() {
 	}
 
 	const hash = window.location.hash || "#login";
-	const route = getMatchingRoute(hash);
+	const route = getMatchingRoute(hash, routes);
 
-	if (!route) {
-		renderLoginPage(app);
-		return;
-	}
-
-	if (!canAccessRoute(route)) {
+	if (!canAccessRoute(route, getAccessToken())) {
 		window.location.hash = "#login";
 		return;
 	}

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,24 @@ import { getAccessToken } from "./services/storage.js";
 
 const app = document.querySelector("#app");
 
+const routes = [
+	{
+		matches: (hash) => hash === "#register",
+		requiresAuth: false,
+		render: (rootElement) => renderRegisterPage(rootElement),
+	},
+	{
+		matches: (hash) => hash === "#feed",
+		requiresAuth: true,
+		render: (rootElement) => renderFeedPage(rootElement),
+	},
+	{
+		matches: (hash) => hash.startsWith("#post"),
+		requiresAuth: true,
+		render: (rootElement) => renderPostDetailPage(rootElement, getPostIdFromHash()),
+	},
+];
+
 function getPostIdFromHash() {
 	const hashValue = window.location.hash || "";
 
@@ -19,37 +37,37 @@ function getPostIdFromHash() {
 	return params.get("id") || "";
 }
 
+function getMatchingRoute(hash) {
+	return routes.find((route) => route.matches(hash)) || null;
+}
+
+function canAccessRoute(route) {
+	if (!route?.requiresAuth) {
+		return true;
+	}
+
+	return Boolean(getAccessToken());
+}
+
 function renderCurrentPage() {
 	if (!app) {
 		return;
 	}
 
-	if (window.location.hash === "#register") {
-		renderRegisterPage(app);
+	const hash = window.location.hash || "#login";
+	const route = getMatchingRoute(hash);
+
+	if (!route) {
+		renderLoginPage(app);
 		return;
 	}
 
-	if (window.location.hash === "#feed") {
-		if (!getAccessToken()) {
-			window.location.hash = "#login";
-			return;
-		}
-
-		renderFeedPage(app);
+	if (!canAccessRoute(route)) {
+		window.location.hash = "#login";
 		return;
 	}
 
-	if (window.location.hash.startsWith("#post")) {
-		if (!getAccessToken()) {
-			window.location.hash = "#login";
-			return;
-		}
-
-		renderPostDetailPage(app, getPostIdFromHash());
-		return;
-	}
-
-	renderLoginPage(app);
+	route.render(app);
 }
 
 window.addEventListener("hashchange", renderCurrentPage);

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,51 @@
+export function getPostIdFromHash(hashValue = window.location.hash || "") {
+	if (!hashValue.startsWith("#post")) {
+		return "";
+	}
+
+	const queryString = hashValue.split("?")[1] || "";
+	const params = new URLSearchParams(queryString);
+	return params.get("id") || "";
+}
+
+export function createRoutes(handlers) {
+	return [
+		{
+			matches: (hash) => hash === "#login" || hash === "",
+			requiresAuth: false,
+			render: (rootElement) => handlers.renderLoginPage(rootElement),
+		},
+		{
+			matches: (hash) => hash === "#register",
+			requiresAuth: false,
+			render: (rootElement) => handlers.renderRegisterPage(rootElement),
+		},
+		{
+			matches: (hash) => hash === "#feed",
+			requiresAuth: true,
+			render: (rootElement) => handlers.renderFeedPage(rootElement),
+		},
+		{
+			matches: (hash) => hash.startsWith("#post"),
+			requiresAuth: true,
+			render: (rootElement) => handlers.renderPostDetailPage(rootElement, getPostIdFromHash()),
+		},
+		{
+			matches: () => true,
+			requiresAuth: false,
+			render: (rootElement) => handlers.renderLoginPage(rootElement),
+		},
+	];
+}
+
+export function getMatchingRoute(hash, routes) {
+	return routes.find((route) => route.matches(hash));
+}
+
+export function canAccessRoute(route, hasToken) {
+	if (!route?.requiresAuth) {
+		return true;
+	}
+
+	return Boolean(hasToken);
+}

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,18 +1,7 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
-const API_KEY = import.meta.env.VITE_NOROFF_API_KEY;
-
-function assertApiConfig() {
-	if (!API_BASE_URL) {
-		throw new Error("Missing VITE_API_BASE_URL in .env");
-	}
-
-	if (!API_KEY) {
-		throw new Error("Missing VITE_NOROFF_API_KEY in .env");
-	}
-}
+import { getApiConfig } from "../config/env.js";
 
 export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
-	assertApiConfig();
+	const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
 
 	const query = new URLSearchParams({
 		page: String(page),
@@ -22,10 +11,10 @@ export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
 		_reactions: "true",
 	});
 
-	const response = await fetch(`${API_BASE_URL}/social/posts?${query.toString()}`, {
+	const response = await fetch(`${apiBaseUrl}/social/posts?${query.toString()}`, {
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
-			"X-Noroff-API-Key": API_KEY,
+			"X-Noroff-API-Key": apiKey,
 		},
 	});
 
@@ -45,7 +34,7 @@ export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
 }
 
 export async function fetchPostById({ accessToken, postId }) {
-	assertApiConfig();
+	const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
 
 	if (!postId) {
 		throw new Error("Post id is required");
@@ -57,10 +46,10 @@ export async function fetchPostById({ accessToken, postId }) {
 		_reactions: "true",
 	});
 
-	const response = await fetch(`${API_BASE_URL}/social/posts/${encodeURIComponent(postId)}?${query.toString()}`, {
+	const response = await fetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}?${query.toString()}`, {
 		headers: {
 			Authorization: `Bearer ${accessToken}`,
-			"X-Noroff-API-Key": API_KEY,
+			"X-Noroff-API-Key": apiKey,
 		},
 	});
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+import { getApiConfig } from "../config/env.js";
 
 export function validateLoginForm(formData) {
 	const errors = {};
@@ -26,7 +26,9 @@ export function validateLoginForm(formData) {
 }
 
 export async function loginUser(credentials) {
-	const response = await fetch(`${API_BASE_URL}/auth/login`, {
+	const { apiBaseUrl } = getApiConfig();
+
+	const response = await fetch(`${apiBaseUrl}/auth/login`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",
@@ -86,7 +88,9 @@ export function validateRegistrationForm(formData) {
 }
 
 export async function registerUser(userData) {
-	const response = await fetch(`${API_BASE_URL}/auth/register`, {
+	const { apiBaseUrl } = getApiConfig();
+
+	const response = await fetch(`${apiBaseUrl}/auth/register`, {
 		method: "POST",
 		headers: {
 			"Content-Type": "application/json",

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -1,0 +1,67 @@
+export function escapeHtml(value) {
+	return String(value || "")
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;")
+		.replaceAll("'", "&#39;");
+}
+
+export function getMediaUrl(media) {
+	const rawUrl = typeof media === "string" ? media : media?.url;
+
+	if (!rawUrl) {
+		return "";
+	}
+
+	try {
+		const parsed = new URL(rawUrl);
+
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			return "";
+		}
+
+		return parsed.toString();
+	} catch {
+		return "";
+	}
+}
+
+export function truncateText(text, maxLength = 150) {
+	const value = text || "";
+
+	if (value.length <= maxLength) {
+		return value;
+	}
+
+	return `${value.slice(0, maxLength)}...`;
+}
+
+export function formatDate(dateString) {
+	if (!dateString) {
+		return "Unknown date";
+	}
+
+	const date = new Date(dateString);
+	return date.toLocaleDateString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export function formatDateTime(dateString) {
+	if (!dateString) {
+		return "Unknown date";
+	}
+
+	const date = new Date(dateString);
+
+	return date.toLocaleString(undefined, {
+		year: "numeric",
+		month: "short",
+		day: "numeric",
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+}


### PR DESCRIPTION
## Why
This PR is a lightweight refactor to improve maintainability and consistency while keeping the app behavior and architecture simple.

## What Changed
### 1) Fixed real data-shape bug
- Updated post-detail comment rendering to support both owner formats:
  - string owner
  - object owner with name
- Prevents incorrect UI output such as `[object Object]` in comments.

### 2) Extracted shared formatting/sanitization helpers
- Added shared utilities in `src/utils/format.js`:
  - `escapeHtml`
  - `getMediaUrl`
  - `truncateText`
  - `formatDate`
  - `formatDateTime`
- Replaced duplicated helper implementations in:
  - `src/features/feed/feed.js`
  - `src/features/feed/post-detail.js`

### 3) Centralized API environment validation
- Added `getApiConfig` in `src/config/env.js`.
- Reused this helper in:
  - `src/services/api.js` (with API key requirement)
  - `src/services/auth.js` (base URL validation)
- Result: consistent env checks and error behavior across services.

### 4) Moved route concerns into router module
- Implemented route utilities in `src/router.js`:
  - `createRoutes`
  - `getMatchingRoute`
  - `canAccessRoute`
  - `getPostIdFromHash`
- Added explicit login route and default catch-all route so unknown hashes are handled by router config.
- Simplified `src/main.js` to focus on rendering flow and auth redirect handling.

## Files Changed
- `src/config/env.js`
- `src/utils/format.js`
- `src/services/api.js`
- `src/services/auth.js`
- `src/features/feed/feed.js`
- `src/features/feed/post-detail.js`
- `src/router.js`
- `src/main.js`

## Behavior Notes
- Unknown hashes now resolve through router default route (login) instead of ad-hoc fallback logic in main.
- Protected routes (`#feed`, `#post`) still require auth token and redirect to login when missing.
- No intended functional changes to feed/post loading beyond the comment-owner rendering fix.

## Validation
- `npm run build` passed.

Closes #21