### PR TITLE
feat: add edit post flow with ownership checks

### DIFF
--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -2,7 +2,7 @@ import { fetchFeedPosts } from '../../services/api.js';
 import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
 import { escapeHtml, formatDate, getMediaUrl, truncateText } from '../../utils/format.js';
 
-function renderPostCard(post) {
+function renderPostCard(post, currentUserName) {
   const mediaUrl = getMediaUrl(post.media);
   const postId = escapeHtml(post.id);
   const authorName = escapeHtml(post.author?.name || 'Unknown');
@@ -11,6 +11,7 @@ function renderPostCard(post) {
   const postBody = escapeHtml(truncateText(post.body));
   const commentsCount = Number(post._count?.comments || 0);
   const reactionsCount = Number(post._count?.reactions || 0);
+  const isOwner = String(post.author?.name || '') === String(currentUserName || '');
 
   return `
 		<article class="post-card" data-post-id="${postId}">
@@ -25,7 +26,14 @@ function renderPostCard(post) {
 				<span>${commentsCount} comments</span>
 				<span>${reactionsCount} reactions</span>
 			</div>
-			<button class="post-open-button" type="button" data-post-id="${postId}">Open post</button>
+      <div class="post-actions">
+        <button class="post-open-button" type="button" data-post-id="${postId}">Open post</button>
+        ${
+          isOwner
+            ? `<button class="post-open-button" type="button" data-edit-post-id="${postId}">Edit post</button>`
+            : ''
+        }
+      </div>
 		</article>
 	`;
 }
@@ -86,6 +94,18 @@ export function renderFeedPage(rootElement) {
     }
 
     const trigger = target.closest('[data-post-id]');
+    const editTrigger = target.closest('[data-edit-post-id]');
+
+    if (editTrigger) {
+      const editPostId = editTrigger.getAttribute('data-edit-post-id');
+
+      if (!editPostId) {
+        return;
+      }
+
+      window.location.hash = `#edit?id=${encodeURIComponent(editPostId)}`;
+      return;
+    }
 
     if (!trigger) {
       return;
@@ -135,7 +155,7 @@ export function renderFeedPage(rootElement) {
 
       feedGrid.insertAdjacentHTML(
         'beforeend',
-        result.posts.map((post) => renderPostCard(post)).join(''),
+        result.posts.map((post) => renderPostCard(post, currentUser.name)).join(''),
       );
 
       feedMessage.textContent = '';

--- a/src/features/feed/post-edit.js
+++ b/src/features/feed/post-edit.js
@@ -1,0 +1,372 @@
+import { fetchPostById, updatePost } from '../../services/api.js';
+import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
+import { getMediaUrl } from '../../utils/format.js';
+import { validateMediaUrl, validatePostForm } from './post-create.js';
+
+const TITLE_MAX_LENGTH = 280;
+const BODY_MAX_LENGTH = 280;
+
+export function getEditPostIdFromHash(hashValue = window.location.hash || '') {
+  if (!hashValue.startsWith('#edit')) {
+    return '';
+  }
+
+  const queryString = hashValue.split('?')[1] || '';
+  const params = new URLSearchParams(queryString);
+  return params.get('id') || '';
+}
+
+export function validatePostOwnership(post, currentUser) {
+  const postOwner = post?.author?.name || '';
+  const currentUserName = currentUser?.name || '';
+  return Boolean(postOwner && currentUserName && postOwner === currentUserName);
+}
+
+function getFormValues(form) {
+  const formData = new FormData(form);
+
+  return {
+    title: formData.get('title'),
+    body: formData.get('body'),
+    tags: formData.get('tags'),
+    media: formData.get('media'),
+  };
+}
+
+function postToFormValues(post) {
+  return {
+    title: String(post?.title || ''),
+    body: String(post?.body || ''),
+    tags: Array.isArray(post?.tags) ? post.tags.join(',') : '',
+    media: String(getMediaUrl(post?.media) || ''),
+  };
+}
+
+function setCounter(input, counter, maxLength) {
+  counter.textContent = `${input.value.length}/${maxLength}`;
+}
+
+function updatePreview(mediaUrl, previewImage, previewMessage) {
+  const trimmedUrl = String(mediaUrl || '').trim();
+
+  if (!trimmedUrl) {
+    previewImage.hidden = true;
+    previewImage.src = '';
+    previewMessage.textContent = 'Enter an image URL to preview media.';
+    return;
+  }
+
+  if (!validateMediaUrl(trimmedUrl)) {
+    previewImage.hidden = true;
+    previewImage.src = '';
+    previewMessage.textContent = 'Preview unavailable. URL must be a valid image link.';
+    return;
+  }
+
+  previewImage.hidden = false;
+  previewImage.src = trimmedUrl;
+  previewMessage.textContent = 'Preview looks good.';
+}
+
+function clearMessages(ui) {
+  ui.message.textContent = '';
+  ui.message.classList.remove('is-error', 'is-success');
+  ui.errors.title.textContent = '';
+  ui.errors.body.textContent = '';
+  ui.errors.tags.textContent = '';
+  ui.errors.media.textContent = '';
+}
+
+function showValidationErrors(ui, errors) {
+  ui.errors.title.textContent = errors.title || '';
+  ui.errors.body.textContent = errors.body || '';
+  ui.errors.tags.textContent = errors.tags || '';
+  ui.errors.media.textContent = errors.media || '';
+}
+
+function setSubmitState(button, isLoading) {
+  button.disabled = isLoading;
+  button.textContent = isLoading ? 'Updating...' : 'Update Post';
+}
+
+function fillForm(ui, values) {
+  ui.titleInput.value = values.title;
+  ui.bodyInput.value = values.body;
+  ui.tagsInput.value = values.tags;
+  ui.mediaInput.value = values.media;
+
+  setCounter(ui.titleInput, ui.titleCounter, TITLE_MAX_LENGTH);
+  setCounter(ui.bodyInput, ui.bodyCounter, BODY_MAX_LENGTH);
+  updatePreview(ui.mediaInput.value, ui.previewImage, ui.previewMessage);
+}
+
+function buildUi(rootElement) {
+  const form = rootElement.querySelector('#edit-post-form');
+  const submit = rootElement.querySelector('#edit-submit');
+  const message = rootElement.querySelector('#edit-message');
+  const titleInput = rootElement.querySelector('#edit-title');
+  const bodyInput = rootElement.querySelector('#edit-body');
+  const tagsInput = rootElement.querySelector('#edit-tags');
+  const mediaInput = rootElement.querySelector('#edit-media');
+  const titleCounter = rootElement.querySelector('#edit-title-counter');
+  const bodyCounter = rootElement.querySelector('#edit-body-counter');
+  const previewImage = rootElement.querySelector('#edit-preview-image');
+  const previewMessage = rootElement.querySelector('#edit-preview-message');
+  const cancelButtons = rootElement.querySelectorAll('#edit-cancel-top, #edit-cancel-bottom');
+
+  const errors = {
+    title: rootElement.querySelector('[data-edit-error-for="title"]'),
+    body: rootElement.querySelector('[data-edit-error-for="body"]'),
+    tags: rootElement.querySelector('[data-edit-error-for="tags"]'),
+    media: rootElement.querySelector('[data-edit-error-for="media"]'),
+  };
+
+  if (
+    !form ||
+    !submit ||
+    !message ||
+    !titleInput ||
+    !bodyInput ||
+    !tagsInput ||
+    !mediaInput ||
+    !titleCounter ||
+    !bodyCounter ||
+    !previewImage ||
+    !previewMessage ||
+    cancelButtons.length === 0 ||
+    !errors.title ||
+    !errors.body ||
+    !errors.tags ||
+    !errors.media
+  ) {
+    return null;
+  }
+
+  return {
+    form,
+    submit,
+    message,
+    titleInput,
+    bodyInput,
+    tagsInput,
+    mediaInput,
+    titleCounter,
+    bodyCounter,
+    previewImage,
+    previewMessage,
+    cancelButtons,
+    errors,
+  };
+}
+
+export function renderPostEditPage(rootElement) {
+  if (!rootElement) {
+    return;
+  }
+
+  const accessToken = getAccessToken();
+
+  if (!accessToken) {
+    window.location.hash = '#login';
+    return;
+  }
+
+  const postId = getEditPostIdFromHash();
+
+  if (!postId) {
+    rootElement.innerHTML = `
+      <main class="feed-page">
+        <p class="feed-message is-error">Missing post id in URL.</p>
+      </main>
+    `;
+    return;
+  }
+
+  rootElement.innerHTML = `
+    <main class="feed-page">
+      <header class="detail-topbar create-topbar">
+        <button class="back-button" id="edit-cancel-top" type="button">Cancel</button>
+        <h1 class="feed-title">Edit Post</h1>
+      </header>
+
+      <section class="post-detail-card" aria-labelledby="edit-post-title">
+        <h2 id="edit-post-title" class="post-detail-title">Update your post</h2>
+        <p class="feed-message" id="edit-load-message" aria-live="polite">Loading post...</p>
+
+        <form id="edit-post-form" class="create-post-form" novalidate hidden>
+          <label class="field-label create-field-label" for="edit-title">Title</label>
+          <input
+            id="edit-title"
+            name="title"
+            type="text"
+            maxlength="${TITLE_MAX_LENGTH}"
+            required
+            class="field-input create-field-input"
+            placeholder="Write a title"
+          />
+          <p class="character-counter" id="edit-title-counter">0/${TITLE_MAX_LENGTH}</p>
+          <p class="field-error create-field-error" data-edit-error-for="title" aria-live="polite"></p>
+
+          <label class="field-label create-field-label" for="edit-body">Body</label>
+          <textarea
+            id="edit-body"
+            name="body"
+            maxlength="${BODY_MAX_LENGTH}"
+            class="field-input create-field-input create-textarea"
+            placeholder="What is on your mind?"
+          ></textarea>
+          <p class="character-counter" id="edit-body-counter">0/${BODY_MAX_LENGTH}</p>
+          <p class="field-error create-field-error" data-edit-error-for="body" aria-live="polite"></p>
+
+          <label class="field-label create-field-label" for="edit-tags">Tags</label>
+          <input
+            id="edit-tags"
+            name="tags"
+            type="text"
+            class="field-input create-field-input"
+            placeholder="javascript,frontend,school"
+          />
+          <p class="field-hint">Use comma-separated tags and avoid spaces in each tag.</p>
+          <p class="field-error create-field-error" data-edit-error-for="tags" aria-live="polite"></p>
+
+          <label class="field-label create-field-label" for="edit-media">Media URL</label>
+          <input
+            id="edit-media"
+            name="media"
+            type="url"
+            class="field-input create-field-input"
+            placeholder="https://example.com/image.jpg"
+          />
+          <p class="field-error create-field-error" data-edit-error-for="media" aria-live="polite"></p>
+
+          <section class="media-preview" aria-live="polite">
+            <p class="field-hint" id="edit-preview-message">Enter an image URL to preview media.</p>
+            <img id="edit-preview-image" class="post-detail-media" alt="Media preview" hidden />
+          </section>
+
+          <div class="create-form-actions">
+            <button class="back-button" id="edit-cancel-bottom" type="button">Cancel</button>
+            <button class="submit-button create-submit-button" id="edit-submit" type="submit">Update Post</button>
+          </div>
+          <p class="form-message create-form-message" id="edit-message" aria-live="polite"></p>
+        </form>
+      </section>
+    </main>
+  `;
+
+  const ui = buildUi(rootElement);
+  const loadMessage = rootElement.querySelector('#edit-load-message');
+
+  if (!ui || !loadMessage) {
+    return;
+  }
+
+  const currentUser = getCurrentUser();
+  let initialSnapshot = '';
+
+  fetchPostById({ accessToken, postId })
+    .then((post) => {
+      if (!post) {
+        loadMessage.textContent = 'Post not found.';
+        loadMessage.classList.add('is-error');
+        return;
+      }
+
+      if (!validatePostOwnership(post, currentUser)) {
+        ui.form.hidden = true;
+        loadMessage.textContent = 'You can only edit your own posts.';
+        loadMessage.classList.add('is-error');
+
+        setTimeout(() => {
+          window.location.hash = '#feed';
+        }, 900);
+        return;
+      }
+
+      fillForm(ui, postToFormValues(post));
+      loadMessage.textContent = '';
+      ui.form.hidden = false;
+      initialSnapshot = JSON.stringify(getFormValues(ui.form));
+    })
+    .catch((error) => {
+      if (error.status === 401) {
+        clearAuthData();
+        window.location.hash = '#login';
+        return;
+      }
+
+      if (error.status === 404) {
+        loadMessage.textContent = 'Post not found.';
+        loadMessage.classList.add('is-error');
+        return;
+      }
+
+      loadMessage.textContent = error.message || 'Could not load post for editing.';
+      loadMessage.classList.add('is-error');
+    });
+
+  ui.titleInput.addEventListener('input', () => {
+    setCounter(ui.titleInput, ui.titleCounter, TITLE_MAX_LENGTH);
+  });
+
+  ui.bodyInput.addEventListener('input', () => {
+    setCounter(ui.bodyInput, ui.bodyCounter, BODY_MAX_LENGTH);
+  });
+
+  ui.mediaInput.addEventListener('input', () => {
+    updatePreview(ui.mediaInput.value, ui.previewImage, ui.previewMessage);
+  });
+
+  ui.cancelButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const currentSnapshot = JSON.stringify(getFormValues(ui.form));
+      const hasUnsavedChanges = initialSnapshot && initialSnapshot !== currentSnapshot;
+
+      if (hasUnsavedChanges && !window.confirm('Discard unsaved changes?')) {
+        return;
+      }
+
+      window.location.hash = '#feed';
+    });
+  });
+
+  ui.form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearMessages(ui);
+
+    const validation = validatePostForm(getFormValues(ui.form));
+
+    if (!validation.isValid) {
+      showValidationErrors(ui, validation.errors);
+      return;
+    }
+
+    setSubmitState(ui.submit, true);
+
+    try {
+      await updatePost({
+        accessToken,
+        postId,
+        postData: validation.data,
+      });
+
+      ui.message.textContent = 'Post updated successfully. Redirecting to feed...';
+      ui.message.classList.add('is-success');
+
+      setTimeout(() => {
+        window.location.hash = '#feed';
+      }, 700);
+    } catch (error) {
+      if (error.status === 401) {
+        clearAuthData();
+        window.location.hash = '#login';
+        return;
+      }
+
+      ui.message.textContent = error.message || 'Could not update post.';
+      ui.message.classList.add('is-error');
+    } finally {
+      setSubmitState(ui.submit, false);
+    }
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { renderLoginPage } from './features/auth/login.js';
 import { renderRegisterPage } from './features/auth/register.js';
 import { renderPostCreatePage } from './features/feed/post-create.js';
 import { renderPostDetailPage } from './features/feed/post-detail.js';
+import { renderPostEditPage } from './features/feed/post-edit.js';
 import { canAccessRoute, createRoutes, getMatchingRoute } from './router.js';
 import { getAccessToken } from './services/storage.js';
 
@@ -15,6 +16,7 @@ const routes = createRoutes({
   renderFeedPage,
   renderPostCreatePage,
   renderPostDetailPage,
+  renderPostEditPage,
 });
 
 function renderCurrentPage() {

--- a/src/router.js
+++ b/src/router.js
@@ -8,6 +8,16 @@ export function getPostIdFromHash(hashValue = window.location.hash || '') {
   return params.get('id') || '';
 }
 
+export function getEditPostIdFromHash(hashValue = window.location.hash || '') {
+  if (!hashValue.startsWith('#edit')) {
+    return '';
+  }
+
+  const queryString = hashValue.split('?')[1] || '';
+  const params = new URLSearchParams(queryString);
+  return params.get('id') || '';
+}
+
 export function createRoutes(handlers) {
   return [
     {
@@ -34,6 +44,11 @@ export function createRoutes(handlers) {
       matches: (hash) => hash.startsWith('#post'),
       requiresAuth: true,
       render: (rootElement) => handlers.renderPostDetailPage(rootElement, getPostIdFromHash()),
+    },
+    {
+      matches: (hash) => hash.startsWith('#edit'),
+      requiresAuth: true,
+      render: (rootElement) => handlers.renderPostEditPage(rootElement),
     },
     {
       matches: () => true,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -96,3 +96,36 @@ export async function createPost({ accessToken, postData }) {
 
   return responseBody?.data || null;
 }
+
+export async function updatePost({ accessToken, postId, postData }) {
+  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+
+  if (!accessToken) {
+    throw new Error('Access token is required');
+  }
+
+  if (!postId) {
+    throw new Error('Post id is required');
+  }
+
+  const response = await fetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}`, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'X-Noroff-API-Key': apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(postData),
+  });
+
+  const responseBody = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+    const error = new Error(apiMessage || 'Failed to update post');
+    error.status = response.status;
+    throw error;
+  }
+
+  return responseBody?.data || null;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -232,8 +232,14 @@ body {
   color: #555555;
 }
 
-.post-open-button {
+.post-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
   margin-top: 0.9rem;
+}
+
+.post-open-button {
   border: 1px solid #111111;
   background: #ffffff;
   color: #111111;

--- a/tests/unit/post-edit.test.js
+++ b/tests/unit/post-edit.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getEditPostIdFromHash, validatePostOwnership } from '../../src/features/feed/post-edit.js';
+
+describe('getEditPostIdFromHash', () => {
+  it('extracts post id from edit hash query', () => {
+    expect(getEditPostIdFromHash('#edit?id=post-1')).toBe('post-1');
+  });
+
+  it('returns empty string when hash is not edit route', () => {
+    expect(getEditPostIdFromHash('#feed')).toBe('');
+  });
+});
+
+describe('validatePostOwnership', () => {
+  it('returns true when current user owns post', () => {
+    const post = { author: { name: 'alice' } };
+    const currentUser = { name: 'alice' };
+
+    expect(validatePostOwnership(post, currentUser)).toBe(true);
+  });
+
+  it('returns false when current user does not own post', () => {
+    const post = { author: { name: 'alice' } };
+    const currentUser = { name: 'bob' };
+
+    expect(validatePostOwnership(post, currentUser)).toBe(false);
+  });
+});

--- a/tests/unit/router.test.js
+++ b/tests/unit/router.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   canAccessRoute,
   createRoutes,
+  getEditPostIdFromHash,
   getMatchingRoute,
   getPostIdFromHash,
 } from '../../src/router.js';
@@ -13,6 +14,7 @@ function buildHandlers() {
     renderFeedPage: vi.fn(),
     renderPostCreatePage: vi.fn(),
     renderPostDetailPage: vi.fn(),
+    renderPostEditPage: vi.fn(),
   };
 }
 
@@ -23,6 +25,16 @@ describe('getPostIdFromHash', () => {
 
   it('returns empty string for non-post hash', () => {
     expect(getPostIdFromHash('#feed')).toBe('');
+  });
+});
+
+describe('getEditPostIdFromHash', () => {
+  it('extracts post id from edit hash query', () => {
+    expect(getEditPostIdFromHash('#edit?id=abc-123')).toBe('abc-123');
+  });
+
+  it('returns empty string for non-edit hash', () => {
+    expect(getEditPostIdFromHash('#feed')).toBe('');
   });
 });
 
@@ -53,6 +65,18 @@ describe('createRoutes + getMatchingRoute', () => {
 
     route.render('app');
     expect(handlers.renderPostCreatePage).toHaveBeenCalledWith('app');
+  });
+
+  it('matches protected edit route', () => {
+    const handlers = buildHandlers();
+    const routes = createRoutes(handlers);
+    const route = getMatchingRoute('#edit?id=post-1', routes);
+
+    expect(route).toBeDefined();
+    expect(route.requiresAuth).toBe(true);
+
+    route.render('app');
+    expect(handlers.renderPostEditPage).toHaveBeenCalledWith('app');
   });
 
   it('falls back to default route for unknown hash', () => {


### PR DESCRIPTION
## Summary
- add edit post page with pre-filled form and update submit flow
- add `updatePost` API helper for PUT `/social/posts/{id}`
- add protected `#edit` route and wire page in main routing
- show `Edit post` action only for the post owner in feed
- add unit tests for edit route parsing and ownership checks

## Verification
- `npm test` (all passing)

Closes #6