### PR TITLE
feat(posts): add delete post flow with confirmation and owner checks

### DIFF
--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -1,6 +1,7 @@
-import { fetchFeedPosts } from '../../services/api.js';
+import { deletePost, fetchFeedPosts } from '../../services/api.js';
 import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
 import { escapeHtml, formatDate, getMediaUrl, truncateText } from '../../utils/format.js';
+import { showConfirmDialog } from '../../ui/confirm.js';
 
 function renderPostCard(post, currentUserName) {
   const mediaUrl = getMediaUrl(post.media);
@@ -30,7 +31,8 @@ function renderPostCard(post, currentUserName) {
         <button class="post-open-button" type="button" data-post-id="${postId}">Open post</button>
         ${
           isOwner
-            ? `<button class="post-open-button" type="button" data-edit-post-id="${postId}">Edit post</button>`
+            ? `<button class="post-open-button" type="button" data-edit-post-id="${postId}">Edit post</button>
+               <button class="post-delete-button" type="button" data-delete-post-id="${postId}" data-post-title="${postTitle}">Delete</button>`
             : ''
         }
       </div>
@@ -95,6 +97,74 @@ export function renderFeedPage(rootElement) {
 
     const trigger = target.closest('[data-post-id]');
     const editTrigger = target.closest('[data-edit-post-id]');
+    const deleteTrigger = target.closest('[data-delete-post-id]');
+
+    if (deleteTrigger) {
+      const deletePostId = deleteTrigger.getAttribute('data-delete-post-id');
+      const postTitle = deleteTrigger.getAttribute('data-post-title') || 'this post';
+
+      if (!deletePostId) {
+        return;
+      }
+
+      showConfirmDialog({
+        title: 'Delete Post',
+        message: `Are you sure you want to delete "${postTitle}"?`,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      }).then(async (confirmed) => {
+        if (!confirmed) {
+          return;
+        }
+
+        const deleteButton =
+          deleteTrigger instanceof HTMLButtonElement
+            ? deleteTrigger
+            : feedGrid.querySelector(`[data-delete-post-id="${deletePostId}"]`);
+
+        if (deleteButton instanceof HTMLButtonElement) {
+          deleteButton.disabled = true;
+          deleteButton.textContent = 'Deleting...';
+        }
+
+        try {
+          await deletePost({ accessToken, postId: deletePostId });
+
+          const card = feedGrid.querySelector(`[data-post-id="${deletePostId}"]`);
+
+          if (card) {
+            card.remove();
+          }
+
+          feedMessage.textContent = 'Post deleted successfully.';
+          feedMessage.classList.remove('is-error');
+          feedMessage.classList.add('is-success');
+        } catch (error) {
+          if (error.status === 401) {
+            clearAuthData();
+            window.location.hash = '#login';
+            return;
+          }
+
+          const messageByStatus = {
+            403: 'You can only delete your own post.',
+            404: 'Post not found.',
+          };
+
+          feedMessage.textContent = messageByStatus[error.status] || error.message || 'Could not delete post.';
+          feedMessage.classList.remove('is-success');
+          feedMessage.classList.add('is-error');
+
+          if (deleteButton instanceof HTMLButtonElement) {
+            deleteButton.disabled = false;
+            deleteButton.textContent = 'Delete';
+          }
+        }
+      });
+
+      return;
+    }
 
     if (editTrigger) {
       const editPostId = editTrigger.getAttribute('data-edit-post-id');
@@ -159,6 +229,7 @@ export function renderFeedPage(rootElement) {
       );
 
       feedMessage.textContent = '';
+      feedMessage.classList.remove('is-error', 'is-success');
       isLastPage = Boolean(result.meta?.isLastPage);
 
       if (isLastPage) {

--- a/src/features/feed/post-detail.js
+++ b/src/features/feed/post-detail.js
@@ -1,6 +1,7 @@
-import { fetchPostById } from '../../services/api.js';
-import { clearAuthData, getAccessToken } from '../../services/storage.js';
+import { deletePost, fetchPostById } from '../../services/api.js';
+import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
 import { escapeHtml, formatDateTime, getMediaUrl } from '../../utils/format.js';
+import { showConfirmDialog } from '../../ui/confirm.js';
 
 function renderComments(comments = []) {
   if (!Array.isArray(comments) || comments.length === 0) {
@@ -47,9 +48,10 @@ function renderReactions(reactions = []) {
 	`;
 }
 
-function renderPostDetail(post) {
+function renderPostDetail(post, currentUser) {
   const title = escapeHtml(post?.title || 'Untitled post');
   const body = escapeHtml(post?.body || '');
+  const rawTitle = String(post?.title || 'Untitled post');
   const authorName = escapeHtml(post?.author?.name || 'Unknown');
   const authorEmail = escapeHtml(post?.author?.email || 'No email');
   const created = escapeHtml(formatDateTime(post?.created));
@@ -58,6 +60,8 @@ function renderPostDetail(post) {
   const safeTags = tags.map((tag) => escapeHtml(tag)).filter(Boolean);
   const commentsCount = Number(post?._count?.comments || post?.comments?.length || 0);
   const reactionsCount = Number(post?._count?.reactions || 0);
+  const isOwner = String(post?.author?.name || '') === String(currentUser?.name || '');
+  const postId = escapeHtml(post?.id || '');
 
   return `
 		<article class="post-detail-card">
@@ -68,6 +72,14 @@ function renderPostDetail(post) {
 			</header>
 
 			<h1 class="post-detail-title">${title}</h1>
+      ${
+        isOwner
+          ? `<div class="post-actions">
+            <button class="post-open-button" type="button" data-edit-post-id="${postId}">Edit post</button>
+            <button class="post-delete-button" type="button" data-delete-post-id="${postId}" data-post-title="${escapeHtml(rawTitle)}">Delete</button>
+          </div>`
+          : ''
+      }
 			<p class="post-detail-body">${body}</p>
 
 			${mediaUrl ? `<img class="post-detail-media" src="${mediaUrl}" alt="Post media" loading="lazy" />` : ''}
@@ -102,6 +114,7 @@ export function renderPostDetailPage(rootElement, postId) {
   }
 
   const accessToken = getAccessToken();
+  const currentUser = getCurrentUser();
 
   if (!accessToken) {
     window.location.hash = '#login';
@@ -143,7 +156,65 @@ export function renderPostDetailPage(rootElement, postId) {
       }
 
       messageElement.textContent = '';
-      contentElement.innerHTML = renderPostDetail(post);
+      messageElement.classList.remove('is-error', 'is-success');
+      contentElement.innerHTML = renderPostDetail(post, currentUser);
+
+      const editButton = contentElement.querySelector('[data-edit-post-id]');
+      const deleteButton = contentElement.querySelector('[data-delete-post-id]');
+
+      if (editButton instanceof HTMLButtonElement) {
+        editButton.addEventListener('click', () => {
+          window.location.hash = `#edit?id=${encodeURIComponent(postId)}`;
+        });
+      }
+
+      if (deleteButton instanceof HTMLButtonElement) {
+        deleteButton.addEventListener('click', async () => {
+          const confirmed = await showConfirmDialog({
+            title: 'Delete Post',
+            message: `Are you sure you want to delete "${post?.title || 'this post'}"?`,
+            confirmText: 'Delete',
+            cancelText: 'Cancel',
+            danger: true,
+          });
+
+          if (!confirmed) {
+            return;
+          }
+
+          deleteButton.disabled = true;
+          deleteButton.textContent = 'Deleting...';
+
+          try {
+            await deletePost({ accessToken, postId });
+            messageElement.textContent = 'Post deleted successfully. Returning to feed...';
+            messageElement.classList.remove('is-error');
+            messageElement.classList.add('is-success');
+
+            setTimeout(() => {
+              window.location.hash = '#feed';
+            }, 700);
+          } catch (error) {
+            if (error.status === 401) {
+              clearAuthData();
+              window.location.hash = '#login';
+              return;
+            }
+
+            const messageByStatus = {
+              403: 'You can only delete your own post.',
+              404: 'Post not found.',
+            };
+
+            messageElement.textContent =
+              messageByStatus[error.status] || error.message || 'Could not delete post.';
+            messageElement.classList.remove('is-success');
+            messageElement.classList.add('is-error');
+            deleteButton.disabled = false;
+            deleteButton.textContent = 'Delete';
+          }
+        });
+      }
     })
     .catch((error) => {
       if (error.status === 401) {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -129,3 +129,38 @@ export async function updatePost({ accessToken, postId, postData }) {
 
   return responseBody?.data || null;
 }
+
+export async function deletePost({ accessToken, postId }) {
+  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+
+  if (!accessToken) {
+    throw new Error('Access token is required');
+  }
+
+  if (!postId) {
+    throw new Error('Post id is required');
+  }
+
+  const response = await fetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}`, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'X-Noroff-API-Key': apiKey,
+    },
+  });
+
+  if (response.status === 204) {
+    return true;
+  }
+
+  const responseBody = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+    const error = new Error(apiMessage || 'Failed to delete post');
+    error.status = response.status;
+    throw error;
+  }
+
+  return true;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -168,6 +168,14 @@ body {
   min-height: 1.2rem;
 }
 
+.feed-message.is-error {
+  color: #b00020;
+}
+
+.feed-message.is-success {
+  color: #0f6d2b;
+}
+
 .feed-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -247,6 +255,21 @@ body {
   border-radius: 4px;
   font-weight: 700;
   cursor: pointer;
+}
+
+.post-delete-button {
+  border: 1px solid #b00020;
+  background: #ffffff;
+  color: #b00020;
+  padding: 0.45rem 0.7rem;
+  border-radius: 4px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.post-delete-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
 }
 
 .load-more-button {
@@ -461,6 +484,64 @@ body {
 .create-form-message {
   text-align: left;
   color: #111111;
+}
+
+.confirm-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+  background: rgb(0 0 0 / 50%);
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.confirm-modal {
+  width: min(100%, 420px);
+  background: #ffffff;
+  border: 1px solid #dddddd;
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.confirm-modal-icon {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.confirm-modal-title {
+  margin: 0.4rem 0 0;
+  color: #111111;
+}
+
+.confirm-modal-message {
+  margin: 0.5rem 0 0;
+  color: #333333;
+  line-height: 1.4;
+}
+
+.confirm-modal-actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.confirm-modal-cancel,
+.confirm-modal-confirm {
+  border: 1px solid #111111;
+  background: #ffffff;
+  color: #111111;
+  padding: 0.45rem 0.7rem;
+  border-radius: 4px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.confirm-modal-confirm.is-danger {
+  border-color: #b00020;
+  background: #b00020;
+  color: #ffffff;
 }
 
 @media (max-width: 520px) {

--- a/src/ui/confirm.js
+++ b/src/ui/confirm.js
@@ -1,0 +1,72 @@
+export function showConfirmDialog({
+  title = 'Confirm action',
+  message = 'Are you sure?',
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  danger = false,
+} = {}) {
+  return new Promise((resolve) => {
+    const backdrop = document.createElement('div');
+    backdrop.className = 'confirm-modal-backdrop';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'confirm-modal';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    dialog.setAttribute('aria-label', title);
+
+    dialog.innerHTML = `
+      <p class="confirm-modal-icon" aria-hidden="true">⚠️</p>
+      <h2 class="confirm-modal-title"></h2>
+      <p class="confirm-modal-message"></p>
+      <div class="confirm-modal-actions">
+        <button type="button" class="confirm-modal-cancel">${cancelText}</button>
+        <button type="button" class="confirm-modal-confirm${danger ? ' is-danger' : ''}">${confirmText}</button>
+      </div>
+    `;
+
+    const titleElement = dialog.querySelector('.confirm-modal-title');
+    const messageElement = dialog.querySelector('.confirm-modal-message');
+    const cancelButton = dialog.querySelector('.confirm-modal-cancel');
+    const confirmButton = dialog.querySelector('.confirm-modal-confirm');
+
+    if (!titleElement || !messageElement || !cancelButton || !confirmButton) {
+      resolve(false);
+      return;
+    }
+
+    titleElement.textContent = title;
+    messageElement.textContent = message;
+
+    function cleanup(result) {
+      document.removeEventListener('keydown', onKeyDown);
+      backdrop.remove();
+      resolve(result);
+    }
+
+    function onKeyDown(event) {
+      if (event.key === 'Escape') {
+        cleanup(false);
+      }
+    }
+
+    backdrop.addEventListener('click', (event) => {
+      if (event.target === backdrop) {
+        cleanup(false);
+      }
+    });
+
+    cancelButton.addEventListener('click', () => {
+      cleanup(false);
+    });
+
+    confirmButton.addEventListener('click', () => {
+      cleanup(true);
+    });
+
+    backdrop.append(dialog);
+    document.body.append(backdrop);
+    document.addEventListener('keydown', onKeyDown);
+    confirmButton.focus();
+  });
+}


### PR DESCRIPTION
## Summary
- add DELETE post API helper
- add reusable confirmation modal utility
- add owner-only delete actions in feed and post detail
- show delete loading states and success/error feedback


Closes #7