### PR TITLE
feat(profile): add user profile page with posts listing and author navigation

### DIFF
--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -6,7 +6,8 @@ import { showConfirmDialog } from '../../ui/confirm.js';
 function renderPostCard(post, currentUserName) {
   const mediaUrl = getMediaUrl(post.media);
   const postId = escapeHtml(post.id);
-  const authorName = escapeHtml(post.author?.name || 'Unknown');
+  const authorRawName = String(post.author?.name || 'Unknown');
+  const authorName = escapeHtml(authorRawName);
   const postDate = escapeHtml(formatDate(post.created));
   const postTitle = escapeHtml(post.title || 'Untitled post');
   const postBody = escapeHtml(truncateText(post.body));
@@ -17,7 +18,7 @@ function renderPostCard(post, currentUserName) {
   return `
 		<article class="post-card" data-post-id="${postId}">
 			<div class="post-header">
-				<p class="post-author">${authorName}</p>
+        <button class="post-author-button" type="button" data-profile-name="${authorName}">${authorName}</button>
 				<p class="post-date">${postDate}</p>
 			</div>
 			<h2 class="post-title">${postTitle}</h2>
@@ -98,6 +99,18 @@ export function renderFeedPage(rootElement) {
     const trigger = target.closest('[data-post-id]');
     const editTrigger = target.closest('[data-edit-post-id]');
     const deleteTrigger = target.closest('[data-delete-post-id]');
+    const profileTrigger = target.closest('[data-profile-name]');
+
+    if (profileTrigger) {
+      const profileName = profileTrigger.getAttribute('data-profile-name');
+
+      if (!profileName) {
+        return;
+      }
+
+      window.location.hash = `#profile?name=${encodeURIComponent(profileName)}`;
+      return;
+    }
 
     if (deleteTrigger) {
       const deletePostId = deleteTrigger.getAttribute('data-delete-post-id');

--- a/src/features/feed/post-detail.js
+++ b/src/features/feed/post-detail.js
@@ -52,7 +52,8 @@ function renderPostDetail(post, currentUser) {
   const title = escapeHtml(post?.title || 'Untitled post');
   const body = escapeHtml(post?.body || '');
   const rawTitle = String(post?.title || 'Untitled post');
-  const authorName = escapeHtml(post?.author?.name || 'Unknown');
+  const authorRawName = String(post?.author?.name || 'Unknown');
+  const authorName = escapeHtml(authorRawName);
   const authorEmail = escapeHtml(post?.author?.email || 'No email');
   const created = escapeHtml(formatDateTime(post?.created));
   const mediaUrl = getMediaUrl(post?.media);
@@ -66,7 +67,7 @@ function renderPostDetail(post, currentUser) {
   return `
 		<article class="post-detail-card">
 			<header class="post-detail-header">
-				<p class="post-detail-author">${authorName}</p>
+        <button class="post-author-button" type="button" data-profile-name="${authorName}">${authorName}</button>
 				<p class="post-detail-email">${authorEmail}</p>
 				<p class="post-detail-date">${created}</p>
 			</header>
@@ -161,6 +162,19 @@ export function renderPostDetailPage(rootElement, postId) {
 
       const editButton = contentElement.querySelector('[data-edit-post-id]');
       const deleteButton = contentElement.querySelector('[data-delete-post-id]');
+      const profileButton = contentElement.querySelector('[data-profile-name]');
+
+      if (profileButton instanceof HTMLButtonElement) {
+        profileButton.addEventListener('click', () => {
+          const profileName = profileButton.getAttribute('data-profile-name');
+
+          if (!profileName) {
+            return;
+          }
+
+          window.location.hash = `#profile?name=${encodeURIComponent(profileName)}`;
+        });
+      }
 
       if (editButton instanceof HTMLButtonElement) {
         editButton.addEventListener('click', () => {

--- a/src/features/profile/profile-view.js
+++ b/src/features/profile/profile-view.js
@@ -1,0 +1,268 @@
+import { fetchProfileByName, fetchProfilePosts } from '../../services/api.js';
+import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
+import { escapeHtml, formatDate, getMediaUrl, truncateText } from '../../utils/format.js';
+
+export function formatCount(value) {
+  const count = Number(value || 0);
+
+  if (count >= 1_000_000) {
+    return `${(count / 1_000_000).toFixed(1).replace('.0', '')}M`;
+  }
+
+  if (count >= 1_000) {
+    return `${(count / 1_000).toFixed(1).replace('.0', '')}K`;
+  }
+
+  return String(count);
+}
+
+function resolveProfileName(profileName) {
+  if (profileName) {
+    return profileName;
+  }
+
+  const hash = window.location.hash || '';
+
+  if (!hash.startsWith('#profile')) {
+    return '';
+  }
+
+  const queryString = hash.split('?')[1] || '';
+  const params = new URLSearchParams(queryString);
+  return params.get('name') || '';
+}
+
+function renderProfileHeader(profile, isOwnProfile) {
+  const bannerUrl = getMediaUrl(profile?.banner);
+  const avatarUrl = getMediaUrl(profile?.avatar);
+  const name = escapeHtml(profile?.name || 'Unknown user');
+  const email = escapeHtml(profile?.email || 'No email');
+  const postsCount = formatCount(profile?._count?.posts || 0);
+  const followersCount = formatCount(profile?._count?.followers || 0);
+  const followingCount = formatCount(profile?._count?.following || 0);
+
+  return `
+    <section class="profile-header-card">
+      <div class="profile-banner" style="background-image: ${bannerUrl ? `url('${bannerUrl}')` : 'linear-gradient(135deg, #f1f5f9, #dbeafe)'}"></div>
+      <div class="profile-header-main">
+        ${
+          avatarUrl
+            ? `<img class="profile-avatar" src="${avatarUrl}" alt="${name} avatar" loading="lazy" />`
+            : '<div class="profile-avatar placeholder">👤</div>'
+        }
+        <div class="profile-header-text">
+          <h1 class="feed-title">${name}</h1>
+          <p class="feed-subtitle">${email}</p>
+          <div class="profile-stats">
+            <span><strong>${postsCount}</strong> posts</span>
+            <span><strong>${followersCount}</strong> followers</span>
+            <span><strong>${followingCount}</strong> following</span>
+          </div>
+        </div>
+        <div class="profile-header-actions">
+          ${
+            isOwnProfile
+              ? '<button class="back-button" type="button" id="profile-edit-button" disabled>Edit Profile</button>'
+              : ''
+          }
+          <button class="back-button" type="button" id="profile-back-button">Back to feed</button>
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+function renderUserPostCard(post) {
+  const mediaUrl = getMediaUrl(post?.media);
+  const postId = escapeHtml(post?.id || '');
+  const title = escapeHtml(post?.title || 'Untitled post');
+  const body = escapeHtml(truncateText(post?.body || ''));
+  const created = escapeHtml(formatDate(post?.created));
+  const commentsCount = Number(post?._count?.comments || 0);
+  const reactionsCount = Number(post?._count?.reactions || 0);
+
+  return `
+    <article class="post-card" data-profile-post-id="${postId}">
+      <div class="post-header">
+        <p class="post-author">${escapeHtml(post?.author?.name || 'Unknown')}</p>
+        <p class="post-date">${created}</p>
+      </div>
+      <h2 class="post-title">${title}</h2>
+      <p class="post-body">${body}</p>
+      ${mediaUrl ? `<img class="post-media" src="${mediaUrl}" alt="Post media" loading="lazy" width="640" height="360" />` : ''}
+      <div class="post-meta">
+        <span>${commentsCount} comments</span>
+        <span>${reactionsCount} reactions</span>
+      </div>
+      <div class="post-actions">
+        <button class="post-open-button" type="button" data-post-id="${postId}">Open post</button>
+      </div>
+    </article>
+  `;
+}
+
+export function renderUserProfilePage(rootElement, profileName) {
+  if (!rootElement) {
+    return;
+  }
+
+  const accessToken = getAccessToken();
+
+  if (!accessToken) {
+    window.location.hash = '#login';
+    return;
+  }
+
+  const resolvedProfileName = resolveProfileName(profileName);
+
+  if (!resolvedProfileName) {
+    rootElement.innerHTML = `
+      <main class="feed-page">
+        <p class="feed-message is-error">Missing profile name in URL.</p>
+      </main>
+    `;
+    return;
+  }
+
+  rootElement.innerHTML = `
+    <main class="feed-page">
+      <p class="feed-message" id="profile-message" aria-live="polite">Loading profile...</p>
+      <section id="profile-header"></section>
+      <section class="feed-grid" id="profile-posts"></section>
+      <button class="load-more-button" id="profile-load-more" type="button">Load More</button>
+    </main>
+  `;
+
+  const profileMessage = rootElement.querySelector('#profile-message');
+  const profileHeader = rootElement.querySelector('#profile-header');
+  const profilePosts = rootElement.querySelector('#profile-posts');
+  const loadMoreButton = rootElement.querySelector('#profile-load-more');
+
+  if (!profileMessage || !profileHeader || !profilePosts || !loadMoreButton) {
+    return;
+  }
+
+  const currentUser = getCurrentUser();
+  const isOwnProfile = String(currentUser.name || '') === String(resolvedProfileName || '');
+
+  let currentPage = 1;
+  let isLastPage = false;
+  let isLoading = false;
+
+  async function loadProfileHeader() {
+    const profile = await fetchProfileByName({ accessToken, profileName: resolvedProfileName });
+
+    if (!profile) {
+      throw new Error('Profile not found.');
+    }
+
+    profileHeader.innerHTML = renderProfileHeader(profile, isOwnProfile);
+
+    const backButton = profileHeader.querySelector('#profile-back-button');
+    if (backButton instanceof HTMLButtonElement) {
+      backButton.addEventListener('click', () => {
+        window.location.hash = '#feed';
+      });
+    }
+  }
+
+  async function loadProfilePosts() {
+    if (isLoading || isLastPage) {
+      return;
+    }
+
+    isLoading = true;
+    loadMoreButton.disabled = true;
+
+    try {
+      const result = await fetchProfilePosts({
+        accessToken,
+        profileName: resolvedProfileName,
+        page: currentPage,
+        limit: 12,
+      });
+
+      if (result.posts.length === 0 && currentPage === 1) {
+        profilePosts.innerHTML = '';
+        profileMessage.textContent = 'This user has no posts yet.';
+        loadMoreButton.style.display = 'none';
+        isLastPage = true;
+        return;
+      }
+
+      profilePosts.insertAdjacentHTML(
+        'beforeend',
+        result.posts.map((post) => renderUserPostCard(post)).join(''),
+      );
+
+      profileMessage.textContent = '';
+      profileMessage.classList.remove('is-error', 'is-success');
+      isLastPage = Boolean(result.meta?.isLastPage);
+
+      if (isLastPage) {
+        loadMoreButton.style.display = 'none';
+      } else {
+        currentPage += 1;
+        loadMoreButton.disabled = false;
+      }
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  profilePosts.addEventListener('click', (event) => {
+    const target = event.target;
+
+    if (!(target instanceof Element)) {
+      return;
+    }
+
+    const trigger = target.closest('[data-post-id]');
+
+    if (!trigger) {
+      return;
+    }
+
+    const postId = trigger.getAttribute('data-post-id');
+
+    if (!postId) {
+      return;
+    }
+
+    window.location.hash = `#post?id=${encodeURIComponent(postId)}`;
+  });
+
+  loadMoreButton.addEventListener('click', () => {
+    loadProfilePosts().catch((error) => {
+      if (error.status === 401) {
+        clearAuthData();
+        window.location.hash = '#login';
+        return;
+      }
+
+      profileMessage.textContent = error.message || 'Could not load profile posts.';
+      profileMessage.classList.remove('is-success');
+      profileMessage.classList.add('is-error');
+      loadMoreButton.disabled = false;
+    });
+  });
+
+  Promise.all([loadProfileHeader(), loadProfilePosts()]).catch((error) => {
+    if (error.status === 401) {
+      clearAuthData();
+      window.location.hash = '#login';
+      return;
+    }
+
+    if (error.status === 404) {
+      profileMessage.textContent = 'User not found.';
+      profileMessage.classList.add('is-error');
+      loadMoreButton.style.display = 'none';
+      return;
+    }
+
+    profileMessage.textContent = error.message || 'Could not load profile.';
+    profileMessage.classList.add('is-error');
+    loadMoreButton.style.display = 'none';
+  });
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import { renderRegisterPage } from './features/auth/register.js';
 import { renderPostCreatePage } from './features/feed/post-create.js';
 import { renderPostDetailPage } from './features/feed/post-detail.js';
 import { renderPostEditPage } from './features/feed/post-edit.js';
+import { renderUserProfilePage } from './features/profile/profile-view.js';
 import { canAccessRoute, createRoutes, getMatchingRoute } from './router.js';
 import { getAccessToken } from './services/storage.js';
 
@@ -17,6 +18,7 @@ const routes = createRoutes({
   renderPostCreatePage,
   renderPostDetailPage,
   renderPostEditPage,
+  renderUserProfilePage,
 });
 
 function renderCurrentPage() {

--- a/src/router.js
+++ b/src/router.js
@@ -18,6 +18,16 @@ export function getEditPostIdFromHash(hashValue = window.location.hash || '') {
   return params.get('id') || '';
 }
 
+export function getProfileNameFromHash(hashValue = window.location.hash || '') {
+  if (!hashValue.startsWith('#profile')) {
+    return '';
+  }
+
+  const queryString = hashValue.split('?')[1] || '';
+  const params = new URLSearchParams(queryString);
+  return params.get('name') || '';
+}
+
 export function createRoutes(handlers) {
   return [
     {
@@ -49,6 +59,11 @@ export function createRoutes(handlers) {
       matches: (hash) => hash.startsWith('#edit'),
       requiresAuth: true,
       render: (rootElement) => handlers.renderPostEditPage(rootElement),
+    },
+    {
+      matches: (hash) => hash.startsWith('#profile'),
+      requiresAuth: true,
+      render: (rootElement) => handlers.renderUserProfilePage(rootElement),
     },
     {
       matches: () => true,

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -164,3 +164,77 @@ export async function deletePost({ accessToken, postId }) {
 
   return true;
 }
+
+export async function fetchProfileByName({ accessToken, profileName }) {
+  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+
+  if (!accessToken) {
+    throw new Error('Access token is required');
+  }
+
+  if (!profileName) {
+    throw new Error('Profile name is required');
+  }
+
+  const response = await fetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'X-Noroff-API-Key': apiKey,
+    },
+  });
+
+  const responseBody = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+    const error = new Error(apiMessage || 'Failed to load profile');
+    error.status = response.status;
+    throw error;
+  }
+
+  return responseBody?.data || null;
+}
+
+export async function fetchProfilePosts({ accessToken, profileName, page = 1, limit = 12 }) {
+  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+
+  if (!accessToken) {
+    throw new Error('Access token is required');
+  }
+
+  if (!profileName) {
+    throw new Error('Profile name is required');
+  }
+
+  const query = new URLSearchParams({
+    page: String(page),
+    limit: String(limit),
+    _author: 'true',
+    _comments: 'true',
+    _reactions: 'true',
+  });
+
+  const response = await fetch(
+    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/posts?${query.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Noroff-API-Key': apiKey,
+      },
+    },
+  );
+
+  const responseBody = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+    const error = new Error(apiMessage || 'Failed to load profile posts');
+    error.status = response.status;
+    throw error;
+  }
+
+  return {
+    posts: responseBody?.data || [],
+    meta: responseBody?.meta || {},
+  };
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -204,6 +204,19 @@ body {
   color: #111111;
 }
 
+.post-author-button {
+  border: 0;
+  background: transparent;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  font-weight: 700;
+  color: #111111;
+  text-align: left;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 .post-date {
   margin: 0;
 }
@@ -544,6 +557,64 @@ body {
   color: #ffffff;
 }
 
+.profile-header-card {
+  border: 1px solid #dddddd;
+  border-radius: 8px;
+  background: #ffffff;
+  overflow: hidden;
+  margin-bottom: 1rem;
+}
+
+.profile-banner {
+  height: 160px;
+  background-size: cover;
+  background-position: center;
+}
+
+.profile-header-main {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 1rem;
+  padding: 1rem;
+  align-items: center;
+}
+
+.profile-avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 999px;
+  object-fit: cover;
+  border: 3px solid #ffffff;
+  margin-top: -36px;
+  background: #ffffff;
+}
+
+.profile-avatar.placeholder {
+  display: grid;
+  place-items: center;
+  font-size: 1.8rem;
+  color: #666666;
+}
+
+.profile-header-text h1 {
+  margin-bottom: 0.3rem;
+}
+
+.profile-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 0.5rem;
+  color: #444444;
+}
+
+.profile-header-actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 @media (max-width: 520px) {
   .login-card {
     padding: 1.2rem;
@@ -568,5 +639,13 @@ body {
 
   .create-form-actions button {
     flex: 1;
+  }
+
+  .profile-header-main {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-header-actions {
+    justify-content: flex-start;
   }
 }


### PR DESCRIPTION
## Summary
- add API methods to fetch profile data and profile posts
- add protected `#profile?name=...` route and profile page rendering
- render profile header (banner/avatar/name/email/stats)
- render selected user posts with pagination and loading/error states
- enable author-to-profile navigation from feed and post detail
- add profile page styling


Closes #8