### PR TITLE
feat(profile): add follow/unfollow toggle on user profiles

### DIFF
--- a/src/features/profile/profile-view.js
+++ b/src/features/profile/profile-view.js
@@ -1,4 +1,9 @@
-import { fetchProfileByName, fetchProfilePosts } from '../../services/api.js';
+import {
+  fetchProfileByName,
+  fetchProfilePosts,
+  followProfile,
+  unfollowProfile,
+} from '../../services/api.js';
 import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
 import { escapeHtml, formatDate, getMediaUrl, truncateText } from '../../utils/format.js';
 
@@ -14,6 +19,31 @@ export function formatCount(value) {
   }
 
   return String(count);
+}
+
+export function isFollowingProfile(profile, currentUserName) {
+  const followers = Array.isArray(profile?.followers) ? profile.followers : [];
+
+  return followers.some((follower) => {
+    const followerName = typeof follower === 'string' ? follower : follower?.name;
+    return String(followerName || '') === String(currentUserName || '');
+  });
+}
+
+function updateFollowButton(button, isFollowing, isLoading) {
+  if (!(button instanceof HTMLButtonElement)) {
+    return;
+  }
+
+  button.disabled = isLoading;
+  button.classList.toggle('follow-button-following', isFollowing);
+
+  if (isLoading) {
+    button.textContent = isFollowing ? 'Unfollowing...' : 'Following...';
+    return;
+  }
+
+  button.textContent = isFollowing ? 'Following' : 'Follow';
 }
 
 function resolveProfileName(profileName) {
@@ -55,7 +85,7 @@ function renderProfileHeader(profile, isOwnProfile) {
           <p class="feed-subtitle">${email}</p>
           <div class="profile-stats">
             <span><strong>${postsCount}</strong> posts</span>
-            <span><strong>${followersCount}</strong> followers</span>
+            <span><strong id="profile-followers-count">${followersCount}</strong> followers</span>
             <span><strong>${followingCount}</strong> following</span>
           </div>
         </div>
@@ -63,7 +93,7 @@ function renderProfileHeader(profile, isOwnProfile) {
           ${
             isOwnProfile
               ? '<button class="back-button" type="button" id="profile-edit-button" disabled>Edit Profile</button>'
-              : ''
+              : '<button class="follow-button" type="button" id="profile-follow-button">Follow</button>'
           }
           <button class="back-button" type="button" id="profile-back-button">Back to feed</button>
         </div>
@@ -144,6 +174,8 @@ export function renderUserProfilePage(rootElement, profileName) {
 
   const currentUser = getCurrentUser();
   const isOwnProfile = String(currentUser.name || '') === String(resolvedProfileName || '');
+  let isFollowing = false;
+  let followerCount = 0;
 
   let currentPage = 1;
   let isLastPage = false;
@@ -156,6 +188,9 @@ export function renderUserProfilePage(rootElement, profileName) {
       throw new Error('Profile not found.');
     }
 
+    isFollowing = isFollowingProfile(profile, currentUser.name);
+    followerCount = Number(profile?._count?.followers || 0);
+
     profileHeader.innerHTML = renderProfileHeader(profile, isOwnProfile);
 
     const backButton = profileHeader.querySelector('#profile-back-button');
@@ -164,6 +199,69 @@ export function renderUserProfilePage(rootElement, profileName) {
         window.location.hash = '#feed';
       });
     }
+
+    if (isOwnProfile) {
+      return;
+    }
+
+    const followButton = profileHeader.querySelector('#profile-follow-button');
+    const followersCountElement = profileHeader.querySelector('#profile-followers-count');
+
+    updateFollowButton(followButton, isFollowing, false);
+
+    if (!(followButton instanceof HTMLButtonElement) || !(followersCountElement instanceof HTMLElement)) {
+      return;
+    }
+
+    followButton.addEventListener('click', async () => {
+      const previousFollowingState = isFollowing;
+      const previousFollowerCount = followerCount;
+
+      isFollowing = !isFollowing;
+      followerCount = isFollowing ? followerCount + 1 : Math.max(0, followerCount - 1);
+
+      updateFollowButton(followButton, isFollowing, true);
+      followersCountElement.textContent = formatCount(followerCount);
+
+      try {
+        const response = previousFollowingState
+          ? await unfollowProfile({ accessToken, profileName: resolvedProfileName })
+          : await followProfile({ accessToken, profileName: resolvedProfileName });
+
+        const resolvedCount = Number(response?._count?.followers);
+
+        if (Number.isFinite(resolvedCount)) {
+          followerCount = resolvedCount;
+          followersCountElement.textContent = formatCount(followerCount);
+        }
+
+        updateFollowButton(followButton, isFollowing, false);
+        profileMessage.textContent = isFollowing ? 'You are now following this user.' : 'You unfollowed this user.';
+        profileMessage.classList.remove('is-error');
+        profileMessage.classList.add('is-success');
+      } catch (error) {
+        isFollowing = previousFollowingState;
+        followerCount = previousFollowerCount;
+
+        updateFollowButton(followButton, isFollowing, false);
+        followersCountElement.textContent = formatCount(followerCount);
+
+        if (error.status === 401) {
+          clearAuthData();
+          window.location.hash = '#login';
+          return;
+        }
+
+        const messageByStatus = {
+          400: 'Could not update follow state.',
+          404: 'User not found.',
+        };
+
+        profileMessage.textContent = messageByStatus[error.status] || error.message || 'Could not update follow state.';
+        profileMessage.classList.remove('is-success');
+        profileMessage.classList.add('is-error');
+      }
+    });
   }
 
   async function loadProfilePosts() {

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -176,12 +176,20 @@ export async function fetchProfileByName({ accessToken, profileName }) {
     throw new Error('Profile name is required');
   }
 
-  const response = await fetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'X-Noroff-API-Key': apiKey,
-    },
+  const query = new URLSearchParams({
+    _followers: 'true',
+    _following: 'true',
   });
+
+  const response = await fetch(
+    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}?${query.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Noroff-API-Key': apiKey,
+      },
+    },
+  );
 
   const responseBody = await response.json().catch(() => ({}));
 
@@ -237,4 +245,72 @@ export async function fetchProfilePosts({ accessToken, profileName, page = 1, li
     posts: responseBody?.data || [],
     meta: responseBody?.meta || {},
   };
+}
+
+export async function followProfile({ accessToken, profileName }) {
+  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+
+  if (!accessToken) {
+    throw new Error('Access token is required');
+  }
+
+  if (!profileName) {
+    throw new Error('Profile name is required');
+  }
+
+  const response = await fetch(
+    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/follow`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Noroff-API-Key': apiKey,
+      },
+    },
+  );
+
+  const responseBody = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+    const error = new Error(apiMessage || 'Failed to follow user');
+    error.status = response.status;
+    throw error;
+  }
+
+  return responseBody?.data || null;
+}
+
+export async function unfollowProfile({ accessToken, profileName }) {
+  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+
+  if (!accessToken) {
+    throw new Error('Access token is required');
+  }
+
+  if (!profileName) {
+    throw new Error('Profile name is required');
+  }
+
+  const response = await fetch(
+    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/unfollow`,
+    {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'X-Noroff-API-Key': apiKey,
+      },
+    },
+  );
+
+  const responseBody = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
+    const error = new Error(apiMessage || 'Failed to unfollow user');
+    error.status = response.status;
+    throw error;
+  }
+
+  return responseBody?.data || null;
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -615,6 +615,32 @@ body {
   justify-content: flex-end;
 }
 
+.follow-button {
+  border: 1px solid #0a66c2;
+  background: #0a66c2;
+  color: #ffffff;
+  padding: 0.5rem 0.8rem;
+  font-weight: 700;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.follow-button:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.follow-button-following {
+  border-color: #888888;
+  background: #ffffff;
+  color: #333333;
+}
+
+.follow-button-following:hover:not(:disabled) {
+  border-color: #b00020;
+  color: #b00020;
+}
+
 @media (max-width: 520px) {
   .login-card {
     padding: 1.2rem;


### PR DESCRIPTION
## Summary
- add follow and unfollow profile API methods
- include followers/following in profile fetch for follow-state detection
- add follow button to user profile header (hidden for own profile)
- implement follow toggle with loading states and feedback messages
- update follower count optimistically and reconcile with API response
- style follow button states (follow, following, hover, disabled)

## Verification
- `npm test`

Closes #9