### PR TITLE
feat(profile): add dedicated my-profile route and own profile access from feed

### DIFF
--- a/src/features/feed/feed.js
+++ b/src/features/feed/feed.js
@@ -65,6 +65,7 @@ export function renderFeedPage(rootElement) {
 					<p class="feed-subtitle">Logged in as ${safeUserName}</p>
 				</div>
         <div class="feed-actions">
+          <button class="my-profile-button" id="my-profile-button" type="button">My Profile</button>
           <button class="create-post-button" id="create-post-button" type="button">Create Post</button>
           <button class="logout-button" id="logout-button" type="button">Log Out</button>
         </div>
@@ -92,6 +93,7 @@ export function renderFeedPage(rootElement) {
   const feedMessage = rootElement.querySelector('#feed-message');
   const loadMoreButton = rootElement.querySelector('#load-more-button');
   const logoutButton = rootElement.querySelector('#logout-button');
+  const myProfileButton = rootElement.querySelector('#my-profile-button');
   const createPostButton = rootElement.querySelector('#create-post-button');
   const searchInput = rootElement.querySelector('#feed-search-input');
   const clearSearchButton = rootElement.querySelector('#feed-search-clear');
@@ -102,6 +104,7 @@ export function renderFeedPage(rootElement) {
     !feedMessage ||
     !loadMoreButton ||
     !logoutButton ||
+    !myProfileButton ||
     !createPostButton ||
     !searchInput ||
     !clearSearchButton ||
@@ -112,6 +115,10 @@ export function renderFeedPage(rootElement) {
 
   createPostButton.addEventListener('click', () => {
     window.location.hash = '#create';
+  });
+
+  myProfileButton.addEventListener('click', () => {
+    window.location.hash = '#my-profile';
   });
 
   feedGrid.addEventListener('click', (event) => {

--- a/src/features/profile/profile-view.js
+++ b/src/features/profile/profile-view.js
@@ -92,7 +92,7 @@ function renderProfileHeader(profile, isOwnProfile) {
         <div class="profile-header-actions">
           ${
             isOwnProfile
-              ? '<button class="back-button" type="button" id="profile-edit-button" disabled>Edit Profile</button>'
+              ? '<button class="back-button" type="button" id="profile-edit-button" disabled>Edit Profile</button><button class="logout-button" type="button" id="profile-logout-button">Log Out</button>'
               : '<button class="follow-button" type="button" id="profile-follow-button">Follow</button>'
           }
           <button class="back-button" type="button" id="profile-back-button">Back to feed</button>
@@ -194,9 +194,18 @@ export function renderUserProfilePage(rootElement, profileName) {
     profileHeader.innerHTML = renderProfileHeader(profile, isOwnProfile);
 
     const backButton = profileHeader.querySelector('#profile-back-button');
+    const logoutButton = profileHeader.querySelector('#profile-logout-button');
+
     if (backButton instanceof HTMLButtonElement) {
       backButton.addEventListener('click', () => {
         window.location.hash = '#feed';
+      });
+    }
+
+    if (logoutButton instanceof HTMLButtonElement) {
+      logoutButton.addEventListener('click', () => {
+        clearAuthData();
+        window.location.hash = '#login';
       });
     }
 
@@ -363,4 +372,17 @@ export function renderUserProfilePage(rootElement, profileName) {
     profileMessage.classList.add('is-error');
     loadMoreButton.style.display = 'none';
   });
+}
+
+export function renderMyProfilePage(rootElement) {
+  const currentUser = getCurrentUser();
+  const ownProfileName = String(currentUser?.name || '');
+
+  if (!ownProfileName) {
+    clearAuthData();
+    window.location.hash = '#login';
+    return;
+  }
+
+  renderUserProfilePage(rootElement, ownProfileName);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import { renderRegisterPage } from './features/auth/register.js';
 import { renderPostCreatePage } from './features/feed/post-create.js';
 import { renderPostDetailPage } from './features/feed/post-detail.js';
 import { renderPostEditPage } from './features/feed/post-edit.js';
-import { renderUserProfilePage } from './features/profile/profile-view.js';
+import { renderMyProfilePage, renderUserProfilePage } from './features/profile/profile-view.js';
 import { canAccessRoute, createRoutes, getMatchingRoute } from './router.js';
 import { getAccessToken } from './services/storage.js';
 
@@ -19,6 +19,7 @@ const routes = createRoutes({
   renderPostDetailPage,
   renderPostEditPage,
   renderUserProfilePage,
+  renderMyProfilePage,
 });
 
 function renderCurrentPage() {

--- a/src/router.js
+++ b/src/router.js
@@ -66,6 +66,11 @@ export function createRoutes(handlers) {
       render: (rootElement) => handlers.renderUserProfilePage(rootElement),
     },
     {
+      matches: (hash) => hash === '#my-profile',
+      requiresAuth: true,
+      render: (rootElement) => handlers.renderMyProfilePage(rootElement),
+    },
+    {
       matches: () => true,
       requiresAuth: false,
       render: (rootElement) => handlers.renderLoginPage(rootElement),

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -177,6 +177,16 @@ body {
   cursor: pointer;
 }
 
+.my-profile-button {
+  border: 1px solid #111111;
+  background: #ffffff;
+  color: #111111;
+  padding: 0.5rem 0.8rem;
+  font-weight: 700;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 .feed-message {
   margin: 0.3rem 0 1rem;
   color: #444444;


### PR DESCRIPTION
## Summary
- add a protected `#my-profile` route
- add a "My Profile" action in feed to navigate directly to own profile
- add own-profile wrapper logic and logout action support
- wire new route renderer in app bootstrap

Closes #11