### PR TITLE
refactor: simplify router, api fetch pattern, and async style

### DIFF
--- a/src/features/feed/post-detail.js
+++ b/src/features/feed/post-detail.js
@@ -9,25 +9,24 @@ function renderComments(comments = []) {
   }
 
   return `
-		<ul class="detail-comments-list">
-			${comments
+    <ul class="detail-comments-list">
+      ${comments
         .map((comment) => {
-          const ownerName =
-            typeof comment.owner === 'string' ? comment.owner : (comment.owner?.name ?? 'Unknown');
+          const ownerName = typeof comment.owner === 'string' ? comment.owner : (comment.owner?.name ?? 'Unknown');
           const owner = escapeHtml(ownerName);
           const body = escapeHtml(comment.body || '');
           const created = escapeHtml(formatDateTime(comment.created));
 
           return `
-						<li class="detail-comment-item">
-							<p class="detail-comment-head">${owner} • ${created}</p>
-							<p class="detail-comment-body">${body}</p>
-						</li>
-					`;
+            <li class="detail-comment-item">
+              <p class="detail-comment-head">${owner} • ${created}</p>
+              <p class="detail-comment-body">${body}</p>
+            </li>
+          `;
         })
         .join('')}
-		</ul>
-	`;
+    </ul>
+  `;
 }
 
 function renderReactions(reactions = []) {
@@ -36,16 +35,16 @@ function renderReactions(reactions = []) {
   }
 
   return `
-		<ul class="detail-reaction-list">
-			${reactions
+    <ul class="detail-reaction-list">
+      ${reactions
         .map((reaction) => {
           const symbol = escapeHtml(reaction.symbol || '?');
           const count = Number(reaction.count || 0);
           return `<li class="detail-reaction-item">${symbol} ${count}</li>`;
         })
         .join('')}
-		</ul>
-	`;
+    </ul>
+  `;
 }
 
 function renderPostDetail(post, currentUser) {
@@ -65,54 +64,52 @@ function renderPostDetail(post, currentUser) {
   const postId = escapeHtml(post?.id || '');
 
   return `
-		<article class="post-detail-card">
-			<header class="post-detail-header">
+    <article class="post-detail-card">
+      <header class="post-detail-header">
         <button class="post-author-button" type="button" data-profile-name="${authorName}">${authorName}</button>
-				<p class="post-detail-email">${authorEmail}</p>
-				<p class="post-detail-date">${created}</p>
-			</header>
+        <p class="post-detail-email">${authorEmail}</p>
+        <p class="post-detail-date">${created}</p>
+      </header>
 
-			<h1 class="post-detail-title">${title}</h1>
+      <h1 class="post-detail-title">${title}</h1>
       ${
         isOwner
           ? `<div class="post-actions">
-            <button class="post-open-button" type="button" data-edit-post-id="${postId}">Edit post</button>
-            <button class="post-delete-button" type="button" data-delete-post-id="${postId}" data-post-title="${escapeHtml(rawTitle)}">Delete</button>
-          </div>`
+              <button class="post-open-button" type="button" data-edit-post-id="${postId}">Edit post</button>
+              <button class="post-delete-button" type="button" data-delete-post-id="${postId}" data-post-title="${escapeHtml(rawTitle)}">Delete</button>
+            </div>`
           : ''
       }
-			<p class="post-detail-body">${body}</p>
+      <p class="post-detail-body">${body}</p>
 
-			${mediaUrl ? `<img class="post-detail-media" src="${mediaUrl}" alt="Post media" loading="lazy" />` : ''}
+      ${mediaUrl ? `<img class="post-detail-media" src="${mediaUrl}" alt="Post media" loading="lazy" />` : ''}
 
-			${
+      ${
         safeTags.length > 0
           ? `<ul class="post-detail-tags">${safeTags.map((tag) => `<li>#${tag}</li>`).join('')}</ul>`
           : ''
       }
 
-			<div class="post-detail-counts">
-				<span>${commentsCount} comments</span>
-				<span>${reactionsCount} reactions</span>
-			</div>
+      <div class="post-detail-counts">
+        <span>${commentsCount} comments</span>
+        <span>${reactionsCount} reactions</span>
+      </div>
 
-			<section class="post-detail-section">
-				<h2>Reactions</h2>
-				${renderReactions(post?.reactions)}
-			</section>
+      <section class="post-detail-section">
+        <h2>Reactions</h2>
+        ${renderReactions(post?.reactions)}
+      </section>
 
-			<section class="post-detail-section">
-				<h2>Comments</h2>
-				${renderComments(post?.comments)}
-			</section>
-		</article>
-	`;
+      <section class="post-detail-section">
+        <h2>Comments</h2>
+        ${renderComments(post?.comments)}
+      </section>
+    </article>
+  `;
 }
 
-export function renderPostDetailPage(rootElement, postId) {
-  if (!rootElement) {
-    return;
-  }
+export async function renderPostDetailPage(rootElement, postId) {
+  if (!rootElement) return;
 
   const accessToken = getAccessToken();
   const currentUser = getCurrentUser();
@@ -123,22 +120,18 @@ export function renderPostDetailPage(rootElement, postId) {
   }
 
   rootElement.innerHTML = `
-		<main class="feed-page">
-			<header class="detail-topbar">
-				<button class="back-button" id="back-to-feed" type="button">Back to feed</button>
-			</header>
-			<p class="feed-message" id="post-detail-message" aria-live="polite">Loading post...</p>
-			<section id="post-detail-content"></section>
-		</main>
-	`;
+    <main class="feed-page">
+      <header class="detail-topbar">
+        <button class="back-button" id="back-to-feed" type="button">Back to feed</button>
+      </header>
+      <p class="feed-message" id="post-detail-message" aria-live="polite">Loading post...</p>
+      <section id="post-detail-content"></section>
+    </main>
+  `;
 
   const backButton = rootElement.querySelector('#back-to-feed');
   const messageElement = rootElement.querySelector('#post-detail-message');
   const contentElement = rootElement.querySelector('#post-detail-content');
-
-  if (!backButton || !messageElement || !contentElement) {
-    return;
-  }
 
   backButton.addEventListener('click', () => {
     window.location.hash = '#feed';
@@ -149,99 +142,80 @@ export function renderPostDetailPage(rootElement, postId) {
     return;
   }
 
-  fetchPostById({ accessToken, postId })
-    .then((post) => {
-      if (!post) {
-        messageElement.textContent = 'Post not found.';
-        return;
-      }
+  let post;
+  try {
+    post = await fetchPostById({ accessToken, postId });
+  } catch (error) {
+    if (error.status === 401) {
+      clearAuthData();
+      window.location.hash = '#login';
+      return;
+    }
+    if (error.status === 404) {
+      messageElement.textContent = 'Post not found.';
+      return;
+    }
+    messageElement.textContent = error.message || 'Could not load post.';
+    return;
+  }
 
-      messageElement.textContent = '';
-      messageElement.classList.remove('is-error', 'is-success');
-      contentElement.innerHTML = renderPostDetail(post, currentUser);
+  if (!post) {
+    messageElement.textContent = 'Post not found.';
+    return;
+  }
 
-      const editButton = contentElement.querySelector('[data-edit-post-id]');
-      const deleteButton = contentElement.querySelector('[data-delete-post-id]');
-      const profileButton = contentElement.querySelector('[data-profile-name]');
+  messageElement.textContent = '';
+  messageElement.classList.remove('is-error', 'is-success');
+  contentElement.innerHTML = renderPostDetail(post, currentUser);
 
-      if (profileButton instanceof HTMLButtonElement) {
-        profileButton.addEventListener('click', () => {
-          const profileName = profileButton.getAttribute('data-profile-name');
+  const editButton = contentElement.querySelector('[data-edit-post-id]');
+  const deleteButton = contentElement.querySelector('[data-delete-post-id]');
+  const profileButton = contentElement.querySelector('[data-profile-name]');
 
-          if (!profileName) {
-            return;
-          }
+  profileButton?.addEventListener('click', () => {
+    const profileName = profileButton.getAttribute('data-profile-name');
+    if (profileName) window.location.hash = `#profile?name=${encodeURIComponent(profileName)}`;
+  });
 
-          window.location.hash = `#profile?name=${encodeURIComponent(profileName)}`;
-        });
-      }
+  editButton?.addEventListener('click', () => {
+    window.location.hash = `#edit?id=${encodeURIComponent(postId)}`;
+  });
 
-      if (editButton instanceof HTMLButtonElement) {
-        editButton.addEventListener('click', () => {
-          window.location.hash = `#edit?id=${encodeURIComponent(postId)}`;
-        });
-      }
+  deleteButton?.addEventListener('click', async () => {
+    const confirmed = await showConfirmDialog({
+      title: 'Delete Post',
+      message: `Are you sure you want to delete "${post?.title || 'this post'}"?`,
+      confirmText: 'Delete',
+      cancelText: 'Cancel',
+      danger: true,
+    });
 
-      if (deleteButton instanceof HTMLButtonElement) {
-        deleteButton.addEventListener('click', async () => {
-          const confirmed = await showConfirmDialog({
-            title: 'Delete Post',
-            message: `Are you sure you want to delete "${post?.title || 'this post'}"?`,
-            confirmText: 'Delete',
-            cancelText: 'Cancel',
-            danger: true,
-          });
+    if (!confirmed) return;
 
-          if (!confirmed) {
-            return;
-          }
+    deleteButton.disabled = true;
+    deleteButton.textContent = 'Deleting...';
 
-          deleteButton.disabled = true;
-          deleteButton.textContent = 'Deleting...';
-
-          try {
-            await deletePost({ accessToken, postId });
-            messageElement.textContent = 'Post deleted successfully. Returning to feed...';
-            messageElement.classList.remove('is-error');
-            messageElement.classList.add('is-success');
-
-            setTimeout(() => {
-              window.location.hash = '#feed';
-            }, 700);
-          } catch (error) {
-            if (error.status === 401) {
-              clearAuthData();
-              window.location.hash = '#login';
-              return;
-            }
-
-            const messageByStatus = {
-              403: 'You can only delete your own post.',
-              404: 'Post not found.',
-            };
-
-            messageElement.textContent =
-              messageByStatus[error.status] || error.message || 'Could not delete post.';
-            messageElement.classList.remove('is-success');
-            messageElement.classList.add('is-error');
-            deleteButton.disabled = false;
-            deleteButton.textContent = 'Delete';
-          }
-        });
-      }
-    })
-    .catch((error) => {
+    try {
+      await deletePost({ accessToken, postId });
+      messageElement.textContent = 'Post deleted successfully. Returning to feed...';
+      messageElement.classList.remove('is-error');
+      messageElement.classList.add('is-success');
+      setTimeout(() => {
+        window.location.hash = '#feed';
+      }, 700);
+    } catch (error) {
       if (error.status === 401) {
         clearAuthData();
         window.location.hash = '#login';
         return;
       }
 
-      if (error.status === 404) {
-        messageElement.textContent = 'Post not found.';
-        return;
-      }
-
-      messageElement.textContent = error.message || 'Could not load post.';
-    });
+      const messageByStatus = { 403: 'You can only delete your own post.', 404: 'Post not found.' };
+      messageElement.textContent = messageByStatus[error.status] || error.message || 'Could not delete post.';
+      messageElement.classList.remove('is-success');
+      messageElement.classList.add('is-error');
+      deleteButton.disabled = false;
+      deleteButton.textContent = 'Delete';
+    }
+  });
 }

--- a/src/features/feed/post-edit.js
+++ b/src/features/feed/post-edit.js
@@ -2,19 +2,10 @@ import { fetchPostById, updatePost } from '../../services/api.js';
 import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
 import { getMediaUrl } from '../../utils/format.js';
 import { validateMediaUrl, validatePostForm } from './post-create.js';
+import { getEditPostIdFromHash } from '../../router.js';
 
 const TITLE_MAX_LENGTH = 280;
 const BODY_MAX_LENGTH = 280;
-
-export function getEditPostIdFromHash(hashValue = window.location.hash || '') {
-  if (!hashValue.startsWith('#edit')) {
-    return '';
-  }
-
-  const queryString = hashValue.split('?')[1] || '';
-  const params = new URLSearchParams(queryString);
-  return params.get('id') || '';
-}
 
 export function validatePostOwnership(post, currentUser) {
   const postOwner = post?.author?.name || '';
@@ -159,7 +150,7 @@ function buildUi(rootElement) {
   };
 }
 
-export function renderPostEditPage(rootElement) {
+export async function renderPostEditPage(rootElement) {
   if (!rootElement) {
     return;
   }
@@ -264,46 +255,42 @@ export function renderPostEditPage(rootElement) {
   const currentUser = getCurrentUser();
   let initialSnapshot = '';
 
-  fetchPostById({ accessToken, postId })
-    .then((post) => {
-      if (!post) {
-        loadMessage.textContent = 'Post not found.';
-        loadMessage.classList.add('is-error');
-        return;
-      }
+  try {
+    const post = await fetchPostById({ accessToken, postId });
 
-      if (!validatePostOwnership(post, currentUser)) {
-        ui.form.hidden = true;
-        loadMessage.textContent = 'You can only edit your own posts.';
-        loadMessage.classList.add('is-error');
-
-        setTimeout(() => {
-          window.location.hash = '#feed';
-        }, 900);
-        return;
-      }
-
-      fillForm(ui, postToFormValues(post));
-      loadMessage.textContent = '';
-      ui.form.hidden = false;
-      initialSnapshot = JSON.stringify(getFormValues(ui.form));
-    })
-    .catch((error) => {
-      if (error.status === 401) {
-        clearAuthData();
-        window.location.hash = '#login';
-        return;
-      }
-
-      if (error.status === 404) {
-        loadMessage.textContent = 'Post not found.';
-        loadMessage.classList.add('is-error');
-        return;
-      }
-
-      loadMessage.textContent = error.message || 'Could not load post for editing.';
+    if (!post) {
+      loadMessage.textContent = 'Post not found.';
       loadMessage.classList.add('is-error');
-    });
+      return;
+    }
+
+    if (!validatePostOwnership(post, currentUser)) {
+      ui.form.hidden = true;
+      loadMessage.textContent = 'You can only edit your own posts.';
+      loadMessage.classList.add('is-error');
+      setTimeout(() => { window.location.hash = '#feed'; }, 900);
+      return;
+    }
+
+    fillForm(ui, postToFormValues(post));
+    loadMessage.textContent = '';
+    ui.form.hidden = false;
+    initialSnapshot = JSON.stringify(getFormValues(ui.form));
+  } catch (error) {
+    if (error.status === 401) {
+      clearAuthData();
+      window.location.hash = '#login';
+      return;
+    }
+    if (error.status === 404) {
+      loadMessage.textContent = 'Post not found.';
+      loadMessage.classList.add('is-error');
+      return;
+    }
+    loadMessage.textContent = error.message || 'Could not load post for editing.';
+    loadMessage.classList.add('is-error');
+    return;
+  }
 
   ui.titleInput.addEventListener('input', () => {
     setCounter(ui.titleInput, ui.titleCounter, TITLE_MAX_LENGTH);

--- a/src/router.js
+++ b/src/router.js
@@ -1,80 +1,24 @@
-export function getPostIdFromHash(hashValue = window.location.hash || '') {
-  if (!hashValue.startsWith('#post')) {
-    return '';
-  }
-
-  const queryString = hashValue.split('?')[1] || '';
-  const params = new URLSearchParams(queryString);
-  return params.get('id') || '';
+function getHashParam(prefix, param) {
+  const hash = window.location.hash || '';
+  if (!hash.startsWith(prefix)) return '';
+  return new URLSearchParams(hash.split('?')[1] || '').get(param) || '';
 }
 
-export function getEditPostIdFromHash(hashValue = window.location.hash || '') {
-  if (!hashValue.startsWith('#edit')) {
-    return '';
-  }
-
-  const queryString = hashValue.split('?')[1] || '';
-  const params = new URLSearchParams(queryString);
-  return params.get('id') || '';
-}
-
-export function getProfileNameFromHash(hashValue = window.location.hash || '') {
-  if (!hashValue.startsWith('#profile')) {
-    return '';
-  }
-
-  const queryString = hashValue.split('?')[1] || '';
-  const params = new URLSearchParams(queryString);
-  return params.get('name') || '';
-}
+export const getPostIdFromHash = () => getHashParam('#post', 'id');
+export const getEditPostIdFromHash = () => getHashParam('#edit', 'id');
+export const getProfileNameFromHash = () => getHashParam('#profile', 'name');
 
 export function createRoutes(handlers) {
   return [
-    {
-      matches: (hash) => hash === '#login' || hash === '',
-      requiresAuth: false,
-      render: (rootElement) => handlers.renderLoginPage(rootElement),
-    },
-    {
-      matches: (hash) => hash === '#register',
-      requiresAuth: false,
-      render: (rootElement) => handlers.renderRegisterPage(rootElement),
-    },
-    {
-      matches: (hash) => hash === '#feed',
-      requiresAuth: true,
-      render: (rootElement) => handlers.renderFeedPage(rootElement),
-    },
-    {
-      matches: (hash) => hash === '#create',
-      requiresAuth: true,
-      render: (rootElement) => handlers.renderPostCreatePage(rootElement),
-    },
-    {
-      matches: (hash) => hash.startsWith('#post'),
-      requiresAuth: true,
-      render: (rootElement) => handlers.renderPostDetailPage(rootElement, getPostIdFromHash()),
-    },
-    {
-      matches: (hash) => hash.startsWith('#edit'),
-      requiresAuth: true,
-      render: (rootElement) => handlers.renderPostEditPage(rootElement),
-    },
-    {
-      matches: (hash) => hash.startsWith('#profile'),
-      requiresAuth: true,
-      render: (rootElement) => handlers.renderUserProfilePage(rootElement),
-    },
-    {
-      matches: (hash) => hash === '#my-profile',
-      requiresAuth: true,
-      render: (rootElement) => handlers.renderMyProfilePage(rootElement),
-    },
-    {
-      matches: () => true,
-      requiresAuth: false,
-      render: (rootElement) => handlers.renderLoginPage(rootElement),
-    },
+    { matches: (hash) => hash === '#login' || hash === '', requiresAuth: false, render: handlers.renderLoginPage },
+    { matches: (hash) => hash === '#register', requiresAuth: false, render: handlers.renderRegisterPage },
+    { matches: (hash) => hash === '#feed', requiresAuth: true, render: handlers.renderFeedPage },
+    { matches: (hash) => hash === '#create', requiresAuth: true, render: handlers.renderPostCreatePage },
+    { matches: (hash) => hash.startsWith('#post'), requiresAuth: true, render: (el) => handlers.renderPostDetailPage(el, getPostIdFromHash()) },
+    { matches: (hash) => hash.startsWith('#edit'), requiresAuth: true, render: handlers.renderPostEditPage },
+    { matches: (hash) => hash.startsWith('#profile'), requiresAuth: true, render: handlers.renderUserProfilePage },
+    { matches: (hash) => hash === '#my-profile', requiresAuth: true, render: handlers.renderMyProfilePage },
+    { matches: () => true, requiresAuth: false, render: handlers.renderLoginPage },
   ];
 }
 
@@ -83,9 +27,6 @@ export function getMatchingRoute(hash, routes) {
 }
 
 export function canAccessRoute(route, hasToken) {
-  if (!route?.requiresAuth) {
-    return true;
-  }
-
+  if (!route?.requiresAuth) return true;
   return Boolean(hasToken);
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,363 +1,113 @@
 import { getApiConfig } from '../config/env.js';
 
-export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
+const POST_PARAMS = { _author: 'true', _comments: 'true', _reactions: 'true' };
 
-  const query = new URLSearchParams({
-    page: String(page),
-    limit: String(limit),
-    _author: 'true',
-    _comments: 'true',
-    _reactions: 'true',
-  });
+async function apiFetch(url, accessToken, options = {}) {
+  const { apiKey } = getApiConfig({ requireApiKey: true });
 
-  const response = await fetch(`${apiBaseUrl}/social/posts?${query.toString()}`, {
+  const response = await fetch(url, {
+    ...options,
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'X-Noroff-API-Key': apiKey,
+      ...options.headers,
     },
   });
 
-  const responseBody = await response.json().catch(() => ({}));
+  if (response.status === 204) return null;
+
+  const body = await response.json().catch(() => ({}));
 
   if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to load feed');
+    const message = body?.errors?.[0]?.message || body?.message;
+    const error = new Error(message || 'Request failed');
     error.status = response.status;
     throw error;
   }
 
-  return {
-    posts: responseBody?.data || [],
-    meta: responseBody?.meta || {},
-  };
+  return body;
+}
+
+export async function fetchFeedPosts({ accessToken, page = 1, limit = 12 }) {
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const query = new URLSearchParams({ page: String(page), limit: String(limit), ...POST_PARAMS });
+  const body = await apiFetch(`${apiBaseUrl}/social/posts?${query}`, accessToken);
+  return { posts: body?.data || [], meta: body?.meta || {} };
 }
 
 export async function searchPosts({ accessToken, queryText, page = 1, limit = 12 }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
   const searchQuery = String(queryText || '').trim();
 
-  if (!searchQuery) {
-    return {
-      posts: [],
-      meta: { isLastPage: true },
-    };
-  }
+  if (!searchQuery) return { posts: [], meta: { isLastPage: true } };
 
-  const query = new URLSearchParams({
-    q: searchQuery,
-    page: String(page),
-    limit: String(limit),
-    _author: 'true',
-    _comments: 'true',
-    _reactions: 'true',
-  });
-
-  const response = await fetch(`${apiBaseUrl}/social/posts/search?${query.toString()}`, {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'X-Noroff-API-Key': apiKey,
-    },
-  });
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to search posts');
-    error.status = response.status;
-    throw error;
-  }
-
-  return {
-    posts: responseBody?.data || [],
-    meta: responseBody?.meta || {},
-  };
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const query = new URLSearchParams({ q: searchQuery, page: String(page), limit: String(limit), ...POST_PARAMS });
+  const body = await apiFetch(`${apiBaseUrl}/social/posts/search?${query}`, accessToken);
+  return { posts: body?.data || [], meta: body?.meta || {} };
 }
 
 export async function fetchPostById({ accessToken, postId }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!postId) {
-    throw new Error('Post id is required');
-  }
-
-  const query = new URLSearchParams({
-    _author: 'true',
-    _comments: 'true',
-    _reactions: 'true',
-  });
-
-  const response = await fetch(
-    `${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}?${query.toString()}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'X-Noroff-API-Key': apiKey,
-      },
-    },
-  );
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to load post');
-    error.status = response.status;
-    throw error;
-  }
-
-  return responseBody?.data || null;
+  if (!postId) throw new Error('Post id is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const query = new URLSearchParams(POST_PARAMS);
+  const body = await apiFetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}?${query}`, accessToken);
+  return body?.data || null;
 }
 
 export async function createPost({ accessToken, postData }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  const response = await fetch(`${apiBaseUrl}/social/posts`, {
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(`${apiBaseUrl}/social/posts`, accessToken, {
     method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'X-Noroff-API-Key': apiKey,
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(postData),
   });
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to create post');
-    error.status = response.status;
-    throw error;
-  }
-
-  return responseBody?.data || null;
+  return body?.data || null;
 }
 
 export async function updatePost({ accessToken, postId, postData }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  if (!postId) {
-    throw new Error('Post id is required');
-  }
-
-  const response = await fetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}`, {
+  if (!postId) throw new Error('Post id is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}`, accessToken, {
     method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'X-Noroff-API-Key': apiKey,
-      'Content-Type': 'application/json',
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(postData),
   });
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to update post');
-    error.status = response.status;
-    throw error;
-  }
-
-  return responseBody?.data || null;
+  return body?.data || null;
 }
 
 export async function deletePost({ accessToken, postId }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  if (!postId) {
-    throw new Error('Post id is required');
-  }
-
-  const response = await fetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}`, {
-    method: 'DELETE',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'X-Noroff-API-Key': apiKey,
-    },
-  });
-
-  if (response.status === 204) {
-    return true;
-  }
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to delete post');
-    error.status = response.status;
-    throw error;
-  }
-
+  if (!postId) throw new Error('Post id is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  await apiFetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}`, accessToken, { method: 'DELETE' });
   return true;
 }
 
 export async function fetchProfileByName({ accessToken, profileName }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  if (!profileName) {
-    throw new Error('Profile name is required');
-  }
-
-  const query = new URLSearchParams({
-    _followers: 'true',
-    _following: 'true',
-  });
-
-  const response = await fetch(
-    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}?${query.toString()}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'X-Noroff-API-Key': apiKey,
-      },
-    },
-  );
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to load profile');
-    error.status = response.status;
-    throw error;
-  }
-
-  return responseBody?.data || null;
+  if (!profileName) throw new Error('Profile name is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const query = new URLSearchParams({ _followers: 'true', _following: 'true' });
+  const body = await apiFetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}?${query}`, accessToken);
+  return body?.data || null;
 }
 
 export async function fetchProfilePosts({ accessToken, profileName, page = 1, limit = 12 }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  if (!profileName) {
-    throw new Error('Profile name is required');
-  }
-
-  const query = new URLSearchParams({
-    page: String(page),
-    limit: String(limit),
-    _author: 'true',
-    _comments: 'true',
-    _reactions: 'true',
-  });
-
-  const response = await fetch(
-    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/posts?${query.toString()}`,
-    {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'X-Noroff-API-Key': apiKey,
-      },
-    },
-  );
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to load profile posts');
-    error.status = response.status;
-    throw error;
-  }
-
-  return {
-    posts: responseBody?.data || [],
-    meta: responseBody?.meta || {},
-  };
+  if (!profileName) throw new Error('Profile name is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const query = new URLSearchParams({ page: String(page), limit: String(limit), ...POST_PARAMS });
+  const body = await apiFetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/posts?${query}`, accessToken);
+  return { posts: body?.data || [], meta: body?.meta || {} };
 }
 
 export async function followProfile({ accessToken, profileName }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  if (!profileName) {
-    throw new Error('Profile name is required');
-  }
-
-  const response = await fetch(
-    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/follow`,
-    {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'X-Noroff-API-Key': apiKey,
-      },
-    },
-  );
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to follow user');
-    error.status = response.status;
-    throw error;
-  }
-
-  return responseBody?.data || null;
+  if (!profileName) throw new Error('Profile name is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/follow`, accessToken, { method: 'PUT' });
+  return body?.data || null;
 }
 
 export async function unfollowProfile({ accessToken, profileName }) {
-  const { apiBaseUrl, apiKey } = getApiConfig({ requireApiKey: true });
-
-  if (!accessToken) {
-    throw new Error('Access token is required');
-  }
-
-  if (!profileName) {
-    throw new Error('Profile name is required');
-  }
-
-  const response = await fetch(
-    `${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/unfollow`,
-    {
-      method: 'PUT',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'X-Noroff-API-Key': apiKey,
-      },
-    },
-  );
-
-  const responseBody = await response.json().catch(() => ({}));
-
-  if (!response.ok) {
-    const apiMessage = responseBody?.errors?.[0]?.message || responseBody?.message;
-    const error = new Error(apiMessage || 'Failed to unfollow user');
-    error.status = response.status;
-    throw error;
-  }
-
-  return responseBody?.data || null;
+  if (!profileName) throw new Error('Profile name is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/unfollow`, accessToken, { method: 'PUT' });
+  return body?.data || null;
 }


### PR DESCRIPTION
Closes #41

## Changes

### `src/services/api.js` — 364 → 115 lines
Extracted a shared `apiFetch` helper that handles auth headers, JSON parsing, and error handling in one place. All 10 API functions now call this helper instead of repeating the same fetch pattern.

### `src/router.js`
- Replaced three nearly-identical hash-parser functions with one shared `getHashParam` helper
- Removed unnecessary wrapper lambdas from route definitions (`(el) => handlers.renderX(el)` → `handlers.renderX`)

### `src/features/feed/post-detail.js`
- Converted `.then().catch()` chain to `async/await` to match the style used in the rest of the codebase
- Removed null guard after `innerHTML` assignment

### `src/features/feed/post-edit.js`
- Converted `.then().catch()` chain to `async/await`
- Removed duplicate local `getEditPostIdFromHash` function, now imported from `router.js`