### PR TITLE
feat: add comments, replies, and emoji reactions to post detail

### DIFF
--- a/src/features/feed/post-detail.js
+++ b/src/features/feed/post-detail.js
@@ -1,24 +1,43 @@
-import { deletePost, fetchPostById } from '../../services/api.js';
+import { createComment, createCommentReply, deletePost, fetchPostById, reactToPost } from '../../services/api.js';
 import { clearAuthData, getAccessToken, getCurrentUser } from '../../services/storage.js';
 import { escapeHtml, formatDateTime, getMediaUrl } from '../../utils/format.js';
 import { showConfirmDialog } from '../../ui/confirm.js';
 
-function renderComments(comments = []) {
-  if (!Array.isArray(comments) || comments.length === 0) {
-    return '<p class="detail-empty">No comments yet.</p>';
-  }
+const EMOJI_OPTIONS = ['👍', '❤️', '😂', '😮', '😢', '😡', '👏', '🔥'];
 
+/**
+ * Organises a flat comments array into a tree of top-level comments with nested replies.
+ * @param {Array} comments - Flat array of comment objects from the API.
+ * @returns {Array} Tree of comment objects, each with a `replies` array.
+ */
+function buildCommentTree(comments) {
+  const map = {};
+  const roots = [];
+  comments.forEach((c) => {
+    map[c.id] = { ...c, replies: [] };
+  });
+  comments.forEach((c) => {
+    if (c.replyToId && map[c.replyToId]) {
+      map[c.replyToId].replies.push(map[c.id]);
+    } else {
+      roots.push(map[c.id]);
+    }
+  });
+  return roots;
+}
+
+function renderReplyList(replies) {
+  if (!replies || replies.length === 0) return '';
   return `
-    <ul class="detail-comments-list">
-      ${comments
-        .map((comment) => {
-          const ownerName = typeof comment.owner === 'string' ? comment.owner : (comment.owner?.name ?? 'Unknown');
+    <ul class="detail-replies-list">
+      ${replies
+        .map((reply) => {
+          const ownerName = typeof reply.owner === 'string' ? reply.owner : (reply.owner?.name ?? 'Unknown');
           const owner = escapeHtml(ownerName);
-          const body = escapeHtml(comment.body || '');
-          const created = escapeHtml(formatDateTime(comment.created));
-
+          const body = escapeHtml(reply.body || '');
+          const created = escapeHtml(formatDateTime(reply.created));
           return `
-            <li class="detail-comment-item">
+            <li class="detail-reply-item">
               <p class="detail-comment-head">${owner} • ${created}</p>
               <p class="detail-comment-body">${body}</p>
             </li>
@@ -29,21 +48,95 @@ function renderComments(comments = []) {
   `;
 }
 
-function renderReactions(reactions = []) {
-  if (!Array.isArray(reactions) || reactions.length === 0) {
-    return '<p class="detail-empty">No reactions yet.</p>';
+function renderComments(comments = []) {
+  if (!Array.isArray(comments) || comments.length === 0) {
+    return '<p class="detail-empty">No comments yet.</p>';
   }
 
+  const tree = buildCommentTree(comments);
+
   return `
-    <ul class="detail-reaction-list">
-      ${reactions
-        .map((reaction) => {
-          const symbol = escapeHtml(reaction.symbol || '?');
-          const count = Number(reaction.count || 0);
-          return `<li class="detail-reaction-item">${symbol} ${count}</li>`;
+    <ul class="detail-comments-list">
+      ${tree
+        .map((comment) => {
+          const ownerName = typeof comment.owner === 'string' ? comment.owner : (comment.owner?.name ?? 'Unknown');
+          const owner = escapeHtml(ownerName);
+          const body = escapeHtml(comment.body || '');
+          const created = escapeHtml(formatDateTime(comment.created));
+          const commentId = escapeHtml(String(comment.id || ''));
+
+          return `
+            <li class="detail-comment-item">
+              <p class="detail-comment-head">${owner} • ${created}</p>
+              <p class="detail-comment-body">${body}</p>
+              <button class="detail-reply-btn" type="button" data-reply-to="${commentId}">Reply</button>
+              <div class="detail-reply-form" id="reply-form-${commentId}" hidden>
+                <textarea class="create-field-input detail-reply-textarea" placeholder="Write a reply..." rows="2" aria-label="Reply to comment"></textarea>
+                <div class="detail-reply-actions">
+                  <button class="post-open-button" type="button" data-submit-reply="${commentId}">Post reply</button>
+                  <button class="back-button" type="button" data-cancel-reply="${commentId}">Cancel</button>
+                </div>
+              </div>
+              ${renderReplyList(comment.replies)}
+            </li>
+          `;
         })
         .join('')}
     </ul>
+  `;
+}
+
+/**
+ * Renders the reactions section with clickable reaction pills and an emoji picker.
+ * @param {Array} reactions - Array of reaction objects with symbol, count, and reactors.
+ * @param {string} currentUserName - The logged-in user's name for highlighting own reactions.
+ * @returns {string} HTML string for the full reactions section.
+ */
+function renderReactions(reactions = [], currentUserName = '') {
+  const reactionHtml =
+    Array.isArray(reactions) && reactions.length > 0
+      ? `<ul class="detail-reaction-list">
+          ${reactions
+            .map((reaction) => {
+              const symbol = escapeHtml(reaction.symbol || '?');
+              const count = Number(reaction.count || 0);
+              const reactors = Array.isArray(reaction.reactors) ? reaction.reactors : [];
+              const hasReacted = reactors.includes(currentUserName);
+              return `<li class="detail-reaction-item">
+                <button class="detail-reaction-btn${hasReacted ? ' is-active' : ''}" type="button" data-react-symbol="${symbol}">${symbol} ${count}</button>
+              </li>`;
+            })
+            .join('')}
+        </ul>`
+      : '<p class="detail-empty">No reactions yet.</p>';
+
+  return `
+    ${reactionHtml}
+    <div class="emoji-picker-container">
+      <button class="post-open-button detail-add-reaction-btn" type="button" id="toggle-emoji-picker">+ React</button>
+      <div class="emoji-picker" id="emoji-picker" hidden>
+        ${EMOJI_OPTIONS.map((emoji) => `<button class="emoji-btn" type="button" data-react-symbol="${emoji}">${emoji}</button>`).join('')}
+      </div>
+    </div>
+  `;
+}
+
+function renderCommentForm() {
+  return `
+    <form class="detail-comment-form" id="comment-form" novalidate>
+      <textarea
+        class="create-field-input detail-comment-textarea"
+        id="comment-body"
+        placeholder="Write a comment..."
+        rows="3"
+        aria-label="Comment"
+        maxlength="500"
+      ></textarea>
+      <div class="detail-comment-actions">
+        <button class="post-open-button" type="submit" id="comment-submit" disabled>Post comment</button>
+      </div>
+      <p class="feed-message" id="comment-message" aria-live="polite"></p>
+    </form>
   `;
 }
 
@@ -61,7 +154,8 @@ function renderPostDetail(post, currentUser) {
   const commentsCount = Number(post?._count?.comments || post?.comments?.length || 0);
   const reactionsCount = Number(post?._count?.reactions || 0);
   const isOwner = String(post?.author?.name || '') === String(currentUser?.name || '');
-  const postId = escapeHtml(post?.id || '');
+  const postId = escapeHtml(String(post?.id || ''));
+  const currentUserName = String(currentUser?.name || '');
 
   return `
     <article class="post-detail-card">
@@ -97,12 +191,13 @@ function renderPostDetail(post, currentUser) {
 
       <section class="post-detail-section">
         <h2>Reactions</h2>
-        ${renderReactions(post?.reactions)}
+        ${renderReactions(post?.reactions, currentUserName)}
       </section>
 
       <section class="post-detail-section">
         <h2>Comments</h2>
         ${renderComments(post?.comments)}
+        ${renderCommentForm()}
       </section>
     </article>
   `;
@@ -142,80 +237,201 @@ export async function renderPostDetailPage(rootElement, postId) {
     return;
   }
 
-  let post;
-  try {
-    post = await fetchPostById({ accessToken, postId });
-  } catch (error) {
-    if (error.status === 401) {
-      clearAuthData();
-      window.location.hash = '#login';
-      return;
-    }
-    if (error.status === 404) {
-      messageElement.textContent = 'Post not found.';
-      return;
-    }
-    messageElement.textContent = error.message || 'Could not load post.';
-    return;
-  }
-
-  if (!post) {
-    messageElement.textContent = 'Post not found.';
-    return;
-  }
-
-  messageElement.textContent = '';
-  messageElement.classList.remove('is-error', 'is-success');
-  contentElement.innerHTML = renderPostDetail(post, currentUser);
-
-  const editButton = contentElement.querySelector('[data-edit-post-id]');
-  const deleteButton = contentElement.querySelector('[data-delete-post-id]');
-  const profileButton = contentElement.querySelector('[data-profile-name]');
-
-  profileButton?.addEventListener('click', () => {
-    const profileName = profileButton.getAttribute('data-profile-name');
-    if (profileName) window.location.hash = `#profile?name=${encodeURIComponent(profileName)}`;
-  });
-
-  editButton?.addEventListener('click', () => {
-    window.location.hash = `#edit?id=${encodeURIComponent(postId)}`;
-  });
-
-  deleteButton?.addEventListener('click', async () => {
-    const confirmed = await showConfirmDialog({
-      title: 'Delete Post',
-      message: `Are you sure you want to delete "${post?.title || 'this post'}"?`,
-      confirmText: 'Delete',
-      cancelText: 'Cancel',
-      danger: true,
-    });
-
-    if (!confirmed) return;
-
-    deleteButton.disabled = true;
-    deleteButton.textContent = 'Deleting...';
-
+  async function loadAndRender() {
+    let post;
     try {
-      await deletePost({ accessToken, postId });
-      messageElement.textContent = 'Post deleted successfully. Returning to feed...';
-      messageElement.classList.remove('is-error');
-      messageElement.classList.add('is-success');
-      setTimeout(() => {
-        window.location.hash = '#feed';
-      }, 700);
+      post = await fetchPostById({ accessToken, postId });
     } catch (error) {
       if (error.status === 401) {
         clearAuthData();
         window.location.hash = '#login';
         return;
       }
+      if (error.status === 404) {
+        messageElement.textContent = 'Post not found.';
+        return;
+      }
+      messageElement.textContent = error.message || 'Could not load post.';
+      return;
+    }
 
-      const messageByStatus = { 403: 'You can only delete your own post.', 404: 'Post not found.' };
-      messageElement.textContent = messageByStatus[error.status] || error.message || 'Could not delete post.';
-      messageElement.classList.remove('is-success');
-      messageElement.classList.add('is-error');
-      deleteButton.disabled = false;
-      deleteButton.textContent = 'Delete';
+    if (!post) {
+      messageElement.textContent = 'Post not found.';
+      return;
+    }
+
+    messageElement.textContent = '';
+    messageElement.classList.remove('is-error', 'is-success');
+    contentElement.innerHTML = renderPostDetail(post, currentUser);
+
+    const editButton = contentElement.querySelector('[data-edit-post-id]');
+    const deleteButton = contentElement.querySelector('[data-delete-post-id]');
+    const profileButton = contentElement.querySelector('[data-profile-name]');
+    const commentBody = contentElement.querySelector('#comment-body');
+    const commentSubmit = contentElement.querySelector('#comment-submit');
+    const commentMessage = contentElement.querySelector('#comment-message');
+    const commentForm = contentElement.querySelector('#comment-form');
+
+    profileButton?.addEventListener('click', () => {
+      const profileName = profileButton.getAttribute('data-profile-name');
+      if (profileName) window.location.hash = `#profile?name=${encodeURIComponent(profileName)}`;
+    });
+
+    editButton?.addEventListener('click', () => {
+      window.location.hash = `#edit?id=${encodeURIComponent(postId)}`;
+    });
+
+    deleteButton?.addEventListener('click', async () => {
+      const postTitle = deleteButton.getAttribute('data-post-title') || 'this post';
+      const confirmed = await showConfirmDialog({
+        title: 'Delete Post',
+        message: `Are you sure you want to delete "${postTitle}"?`,
+        confirmText: 'Delete',
+        cancelText: 'Cancel',
+        danger: true,
+      });
+
+      if (!confirmed) return;
+
+      deleteButton.disabled = true;
+      deleteButton.textContent = 'Deleting...';
+
+      try {
+        await deletePost({ accessToken, postId });
+        messageElement.textContent = 'Post deleted successfully. Returning to feed...';
+        messageElement.classList.remove('is-error');
+        messageElement.classList.add('is-success');
+        setTimeout(() => {
+          window.location.hash = '#feed';
+        }, 700);
+      } catch (error) {
+        if (error.status === 401) {
+          clearAuthData();
+          window.location.hash = '#login';
+          return;
+        }
+        const messageByStatus = { 403: 'You can only delete your own post.', 404: 'Post not found.' };
+        messageElement.textContent = messageByStatus[error.status] || error.message || 'Could not delete post.';
+        messageElement.classList.remove('is-success');
+        messageElement.classList.add('is-error');
+        deleteButton.disabled = false;
+        deleteButton.textContent = 'Delete';
+      }
+    });
+
+    commentBody?.addEventListener('input', () => {
+      if (commentSubmit) commentSubmit.disabled = !commentBody.value.trim();
+    });
+
+    commentForm?.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const text = commentBody?.value.trim();
+      if (!text) return;
+
+      commentSubmit.disabled = true;
+      commentSubmit.textContent = 'Posting...';
+      commentMessage.textContent = '';
+      commentMessage.classList.remove('is-error', 'is-success');
+
+      try {
+        await createComment({ accessToken, postId, commentBody: text });
+        await loadAndRender();
+      } catch (error) {
+        if (error.status === 401) {
+          clearAuthData();
+          window.location.hash = '#login';
+          return;
+        }
+        commentMessage.textContent = error.message || 'Could not post comment.';
+        commentMessage.classList.add('is-error');
+        commentSubmit.disabled = false;
+        commentSubmit.textContent = 'Post comment';
+      }
+    });
+  }
+
+  contentElement.addEventListener('click', async (event) => {
+    const replyBtn = event.target.closest('[data-reply-to]');
+    if (replyBtn) {
+      const commentId = replyBtn.getAttribute('data-reply-to');
+      const replyForm = contentElement.querySelector(`#reply-form-${CSS.escape(commentId)}`);
+      if (replyForm) {
+        replyForm.hidden = !replyForm.hidden;
+        if (!replyForm.hidden) replyForm.querySelector('textarea')?.focus();
+      }
+      return;
+    }
+
+    const cancelBtn = event.target.closest('[data-cancel-reply]');
+    if (cancelBtn) {
+      const commentId = cancelBtn.getAttribute('data-cancel-reply');
+      const replyForm = contentElement.querySelector(`#reply-form-${CSS.escape(commentId)}`);
+      if (replyForm) {
+        replyForm.hidden = true;
+        const textarea = replyForm.querySelector('textarea');
+        if (textarea) textarea.value = '';
+      }
+      return;
+    }
+
+    const submitBtn = event.target.closest('[data-submit-reply]');
+    if (submitBtn) {
+      const commentId = submitBtn.getAttribute('data-submit-reply');
+      const replyForm = contentElement.querySelector(`#reply-form-${CSS.escape(commentId)}`);
+      const textarea = replyForm?.querySelector('textarea');
+      const text = textarea?.value.trim();
+      if (!text) return;
+
+      submitBtn.disabled = true;
+      submitBtn.textContent = 'Posting...';
+
+      try {
+        await createCommentReply({ accessToken, postId, commentId, replyBody: text });
+        await loadAndRender();
+      } catch (error) {
+        if (error.status === 401) {
+          clearAuthData();
+          window.location.hash = '#login';
+          return;
+        }
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Post reply';
+      }
+      return;
+    }
+
+    if (event.target.closest('#toggle-emoji-picker')) {
+      const picker = contentElement.querySelector('#emoji-picker');
+      if (picker) picker.hidden = !picker.hidden;
+      return;
+    }
+
+    const reactBtn = event.target.closest('[data-react-symbol]');
+    if (reactBtn) {
+      const picker = contentElement.querySelector('#emoji-picker');
+      if (picker && !picker.hidden) picker.hidden = true;
+
+      const symbol = reactBtn.getAttribute('data-react-symbol');
+      if (!symbol) return;
+
+      try {
+        await reactToPost({ accessToken, postId, symbol });
+        await loadAndRender();
+      } catch (error) {
+        if (error.status === 401) {
+          clearAuthData();
+          window.location.hash = '#login';
+        }
+      }
     }
   });
+
+  document.addEventListener('click', (event) => {
+    const picker = contentElement.querySelector('#emoji-picker');
+    if (picker && !picker.hidden && !event.target.closest('.emoji-picker-container')) {
+      picker.hidden = true;
+    }
+  });
+
+  await loadAndRender();
 }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -111,3 +111,53 @@ export async function unfollowProfile({ accessToken, profileName }) {
   const body = await apiFetch(`${apiBaseUrl}/social/profiles/${encodeURIComponent(profileName)}/unfollow`, accessToken, { method: 'PUT' });
   return body?.data || null;
 }
+
+/**
+ * Adds a comment to a post.
+ * @param {{ accessToken: string, postId: string|number, commentBody: string }} params
+ * @returns {Promise<object|null>} The created comment data.
+ */
+export async function createComment({ accessToken, postId, commentBody }) {
+  if (!postId) throw new Error('Post id is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}/comment`, accessToken, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: commentBody, replyToId: null }),
+  });
+  return body?.data || null;
+}
+
+/**
+ * Adds a reply to an existing comment on a post.
+ * @param {{ accessToken: string, postId: string|number, commentId: string, replyBody: string }} params
+ * @returns {Promise<object|null>} The created reply data.
+ */
+export async function createCommentReply({ accessToken, postId, commentId, replyBody }) {
+  if (!postId) throw new Error('Post id is required');
+  if (!commentId) throw new Error('Comment id is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(`${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}/comment`, accessToken, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ body: replyBody, replyToId: commentId }),
+  });
+  return body?.data || null;
+}
+
+/**
+ * Reacts to a post with an emoji symbol. Calling with the same emoji toggles the reaction off.
+ * @param {{ accessToken: string, postId: string|number, symbol: string }} params
+ * @returns {Promise<object|null>} The updated post data with reactions.
+ */
+export async function reactToPost({ accessToken, postId, symbol }) {
+  if (!postId) throw new Error('Post id is required');
+  if (!symbol) throw new Error('Reaction symbol is required');
+  const { apiBaseUrl } = getApiConfig({ requireApiKey: true });
+  const body = await apiFetch(
+    `${apiBaseUrl}/social/posts/${encodeURIComponent(postId)}/react/${encodeURIComponent(symbol)}`,
+    accessToken,
+    { method: 'PUT' },
+  );
+  return body?.data || null;
+}

--- a/src/styles/features.css
+++ b/src/styles/features.css
@@ -387,6 +387,114 @@
   justify-content: flex-end;
 }
 
+/* Comments & Reactions - interactive features */
+
+.detail-reaction-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.detail-reaction-item {
+  border: none;
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+}
+
+.detail-reaction-btn {
+  border: 1px solid #dddddd;
+  border-radius: 999px;
+  background: #f5f5f5;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.detail-reaction-btn:hover { background: #ebebeb; }
+
+.detail-reaction-btn.is-active {
+  border-color: #0a66c2;
+  background: #e8f0fa;
+  color: #0a66c2;
+  font-weight: 700;
+}
+
+.emoji-picker-container { position: relative; display: inline-block; }
+.detail-add-reaction-btn { font-size: 0.85rem; padding: 0.3rem 0.65rem; }
+
+.emoji-picker {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  background: #ffffff;
+  border: 1px solid #dddddd;
+  border-radius: 8px;
+  padding: 0.5rem;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+  width: max-content;
+}
+
+.emoji-btn {
+  border: 1px solid transparent;
+  background: transparent;
+  border-radius: 4px;
+  padding: 0.3rem;
+  font-size: 1.3rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.emoji-btn:hover { background: #f0f0f0; border-color: #dddddd; }
+
+.detail-comment-form {
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid #efefef;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-comment-textarea { min-height: 80px; resize: vertical; border-color: #bbbbbb; color: #111111; }
+.detail-comment-actions { display: flex; justify-content: flex-end; }
+
+.detail-reply-btn {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin-top: 0.35rem;
+  font-size: 0.82rem;
+  color: #0a66c2;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.detail-reply-form { margin-top: 0.5rem; display: grid; gap: 0.4rem; }
+.detail-reply-textarea { min-height: 60px; resize: vertical; border-color: #bbbbbb; font-size: 0.9rem; color: #111111; }
+.detail-reply-actions { display: flex; gap: 0.4rem; justify-content: flex-end; }
+
+.detail-replies-list {
+  list-style: none;
+  padding: 0 0 0 1.25rem;
+  margin: 0.5rem 0 0;
+  display: grid;
+  gap: 0.4rem;
+  border-left: 2px solid #eeeeee;
+}
+
+.detail-reply-item {
+  border: 1px solid #eeeeee;
+  border-radius: 6px;
+  padding: 0.45rem 0.6rem;
+  background: #fbfbfb;
+}
+
 @media (max-width: 520px) {
   .create-topbar {
     flex-wrap: wrap;


### PR DESCRIPTION
- Add createComment, createCommentReply, and reactToPost API functions to src/services/api.js with JSDoc annotations
- Update post detail page to render an interactive comment form below the comments section; comments reload in place after submission
- Add threaded reply support: each comment has a Reply button that shows an inline reply form using the same API endpoint with replyToId
- Replace static reaction display with clickable reaction pills (highlighted when the current user has reacted) and a "+ React" emoji picker with 8 common emojis; reactions toggle on re-click
- Add CSS for reaction pills, emoji picker panel, comment form, reply forms, and indented reply threads
